### PR TITLE
Use workflow detect

### DIFF
--- a/.github/workflows/slsa2_provenance.yml
+++ b/.github/workflows/slsa2_provenance.yml
@@ -48,6 +48,11 @@ jobs:
       id-token: write # Needed for keyless.
       contents: read
     steps:
+      # Check out the base repository to get the detect-workflow action.
+      - name: Checkout the repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
+        with:
+          fetch-depth: 0
       - name: Run local detect action
         id: detect
         uses: ./.github/actions/detect-workflow

--- a/.github/workflows/slsa2_provenance.yml
+++ b/.github/workflows/slsa2_provenance.yml
@@ -17,11 +17,6 @@ name: SLSA provenance generator
 permissions:
   contents: read
 
-env:
-  # This repo.
-  GENERATOR_REPOSITORY: slsa-framework/slsa-github-generator
-  GENERATOR_REF: main
-
 ###################################################################
 #                                                                 #
 #            Input and output argument definitions                #
@@ -53,13 +48,15 @@ jobs:
       id-token: write # Needed for keyless.
       contents: read
     steps:
+      - name: Run local detect action
+        id: detect
+        uses: ./.github/actions/detect-workflow
       - name: Checkout the repository
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
         with:
           fetch-depth: 0
-          repository: "${{ env.GENERATOR_REPOSITORY }}"
-          ref: "${{ env.GENERATOR_REF }}"
-
+          repository: "${{ steps.detect.outputs.repository }}"
+          ref: "${{ steps.detect.outputs.ref }}"
       - name: Set up golang environment
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.3
         with:

--- a/.github/workflows/slsa2_provenance.yml
+++ b/.github/workflows/slsa2_provenance.yml
@@ -35,6 +35,33 @@ on:
         value: ${{ jobs.generator.outputs.signed-provenance-name }}
 
 jobs:
+  detect-env:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to detect the current reusable repository and ref.
+      contents: read
+    outputs:
+      repository: ${{ steps.detect.outputs.repository }}
+      ref: ${{ steps.detect.outputs.ref }}
+    steps:
+      - name: Detect the repository and ref
+        id: detect
+        shell: bash
+        run: |
+          status_code=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=slsa-framework/slsa-github-generator" -o jwt.json -w '%{http_code}')
+          if [[ $status_code -lt 200 ]] || [[ $status_code -ge 300 ]]; then
+              error_msg=$(jq -r .message jwt.json 2>/dev/null || echo 'unknown error')
+              echo "Failed to get OIDC token from GitHub, response $status_code: $error_msg"
+              exit 1;
+          fi
+          export WORKFLOW_REF=$(cat jwt.json | jq -r '.value' | cut -d "." -f2 | base64 -d | jq -r '.job_workflow_ref')
+          if [ -z $WORKFLOW_REF ]; then
+            echo "OIDC token parsing failure: job_workflow_ref could not be retrieved"
+            exit 1;
+          fi
+          echo "::set-output name=repository::$(echo $WORKFLOW_REF | cut -d "@" -f1 | cut -d '/' -f1-2)"
+          echo "::set-output name=ref::$(echo $WORKFLOW_REF | cut -d "@" -f2)"
+
   ###################################################################
   #                                                                 #
   #                       Build the generator                       #
@@ -44,24 +71,17 @@ jobs:
     outputs:
       signed-provenance-name: ${{ steps.sign-prov.outputs.signed-provenance-name }}
     runs-on: ubuntu-latest
+    needs: [detect-env]
     permissions:
       id-token: write # Needed for keyless.
       contents: read
     steps:
-      # Check out the base repository to get the detect-workflow action.
       - name: Checkout the repository
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
         with:
           fetch-depth: 0
-      - name: Run local detect action
-        id: detect
-        uses: ./.github/actions/detect-workflow
-      - name: Checkout the repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
-        with:
-          fetch-depth: 0
-          repository: "${{ steps.detect.outputs.repository }}"
-          ref: "${{ steps.detect.outputs.ref }}"
+          repository: "${{ needs.detect-env.outputs.repository }}"
+          ref: "${{ needs.detect-env.outputs.ref }}"
       - name: Set up golang environment
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.3
         with:


### PR DESCRIPTION
Adds repository and ref detection to the reusable workflow.

Uses bash code to get the OIDC token and detect the repository/ref. This is because the reusable workflow yaml is retrieved and used on it's own and has no context for the rest of the reusable workflow's repo.

We would like to use the lovely code that @asraa wrote to [detect the workflow repository and ref](https://github.com/slsa-framework/slsa-github-generator/tree/main/.github/actions/detect-workflow), but we have a chicken and egg scenario because we need to [check out the slsa-github-generator repo](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow) before using actions defined in the same repo.

I'm not particularly happy with any of the options so I'm open to suggestions for more alternatives.

## This PR's current implementation: Bash code to get and parse the OIDC token
Bash code to get the OIDC token with curl and parse with jq

Pros:
- Code is inline in the workflow so no need to checkout the rest of the repo.
- No need to use a static repo/ref

Cons:
- Need to copy this code and maintain in all reusable workflows
- No OIDC token verification

## Alternative 1: Set a static repo/ref to a well known version when we release one in order to bootstrap the detection process.
  1. Checkout static repo/ref
  1. Run detect-workflow
  1. Check out repo/ref detected by the detect-workflow step.

Pros:
- Able to reuse OIDC token retrieval code from library
- Able to reuse the action code
- Includes OIDC token verification

Cons:
- Need to bootstrap with a static repo/ref