### PR TITLE
Return log entry from rekor upload call

### DIFF
--- a/cmd/slsa-github-generator/attest.go
+++ b/cmd/slsa-github-generator/attest.go
@@ -133,7 +133,8 @@ run in the context of a Github Actions workflow.`,
 				att, err := s.Sign(ctx, p)
 				check(err)
 
-				check(s.Upload(ctx, att))
+				_, err = s.Upload(ctx, att)
+				check(err)
 
 				f, err := getFile(attPath)
 				check(err)

--- a/signing/sigstore/signer.go
+++ b/signing/sigstore/signer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/providers"
+	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -115,15 +116,16 @@ func (s *Signer) Sign(ctx context.Context, p *intoto.ProvenanceStatement) (*Atte
 }
 
 // Upload uploads the signed attestation to the rekor transparency log.
-func (s *Signer) Upload(ctx context.Context, att *Attestation) error {
+func (s *Signer) Upload(ctx context.Context, att *Attestation) (*models.LogEntryAnon, error) {
 	rekorClient, err := rekor.NewClient(s.rekorAddr)
 	if err != nil {
-		return fmt.Errorf("creating rekor client: %w", err)
+		return nil, fmt.Errorf("creating rekor client: %w", err)
 	}
 	// TODO: Is it a bug that we need []byte(string(k.Cert)) or else we hit invalid PEM?
-	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, att.att, []byte(string(att.cert))); err != nil {
-		return fmt.Errorf("uploading attestation: %w", err)
+	logEntry, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, att.att, []byte(string(att.cert)))
+	if err != nil {
+		return nil, fmt.Errorf("uploading attestation: %w", err)
 	}
 
-	return nil
+	return logEntry, nil
 }


### PR DESCRIPTION
Return log entry object so that the caller can output information about log ID.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>