### PR TITLE
Make Sign take generic intoto.Statement

### DIFF
--- a/cmd/slsa-github-generator/attest.go
+++ b/cmd/slsa-github-generator/attest.go
@@ -130,7 +130,10 @@ run in the context of a Github Actions workflow.`,
 
 			if attPath != "" {
 				s := sigstore.NewDefaultSigner()
-				att, err := s.Sign(ctx, p)
+				att, err := s.Sign(ctx, &intoto.Statement{
+					StatementHeader: p.StatementHeader,
+					Predicate:       p.Predicate,
+				})
 				check(err)
 
 				_, err = s.Upload(ctx, att)

--- a/signing/sigstore/signer.go
+++ b/signing/sigstore/signer.go
@@ -79,7 +79,7 @@ func NewSigner(fulcioAddr, rekorAddr, oidcIssuer, oidcClientID string) Signer {
 
 // Sign signs the given provenance statement and returns the signed
 // attestation.
-func (s *Signer) Sign(ctx context.Context, p *intoto.ProvenanceStatement) (*Attestation, error) {
+func (s *Signer) Sign(ctx context.Context, p *intoto.Statement) (*Attestation, error) {
 	// Get Fulcio signer
 	if !providers.Enabled(ctx) {
 		return nil, fmt.Errorf("no auth provider is enabled. Are you running outside of Github Actions?")


### PR DESCRIPTION
Make signing library more generic for intoto statements.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>