### PR TITLE
Fix sha for distroless

### DIFF
--- a/.github/actions/detect-workflow/Dockerfile
+++ b/.github/actions/detect-workflow/Dockerfile
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -v -o app .
 
 # A distroless container image with some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/static@sha256:0bec8e882c023de03ba9ed6bb07cd6b5e52b19fb1641505ea1b1c8937f3ccc7d
+FROM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
 
 COPY --from=builder /app/app /app
 


### PR DESCRIPTION
The previously used distroless sha seems to have had missing layers as I got a `ApplyLayer exit status 1 unexpected EOF` when attempting to execute the action.