### PR TITLE
Return an error when OIDC server not available

### DIFF
--- a/github/oidc.go
+++ b/github/oidc.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -53,6 +52,11 @@ type OIDCToken struct {
 	JobWorkflowRef string `json:"job_workflow_ref"`
 }
 
+// errURLError indicates the OIDC server URL is invalid.
+type errURLError struct {
+	errors.WrappableError
+}
+
 // errRequestError indicates an error requesting the token from the issuer.
 type errRequestError struct {
 	errors.WrappableError
@@ -84,9 +88,9 @@ type OIDCClient struct {
 // NewOIDCClient returns new GitHub OIDC provider client.
 func NewOIDCClient() (*OIDCClient, error) {
 	requestURL := os.Getenv(requestURLEnvKey)
-	parsedURL, err := url.Parse(requestURL)
+	parsedURL, err := url.ParseRequestURI(requestURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid request URL %q: %w", requestURL, err)
+		return nil, errors.Errorf(&errURLError{}, "invalid request URL %q: %w", requestURL, err)
 	}
 
 	c := OIDCClient{

--- a/github/oidc.go
+++ b/github/oidc.go
@@ -90,7 +90,7 @@ func NewOIDCClient() (*OIDCClient, error) {
 	requestURL := os.Getenv(requestURLEnvKey)
 	parsedURL, err := url.ParseRequestURI(requestURL)
 	if err != nil {
-		return nil, errors.Errorf(&errURLError{}, "invalid request URL %q: %w", requestURL, err)
+		return nil, errors.Errorf(&errURLError{}, "invalid request URL %q: %w; does your workflow have `id-token: write` scope?", requestURL, err)
 	}
 
 	c := OIDCClient{

--- a/github/oidc_test.go
+++ b/github/oidc_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -44,6 +45,24 @@ func tokenEqual(issuer string, wantToken, gotToken *OIDCToken) bool {
 	}
 
 	return true
+}
+
+func TestNewOIDCClient(t *testing.T) {
+	// Tests that NewOIDCClient returns an error when the
+	// ACTIONS_ID_TOKEN_REQUEST_URL env var is empty.
+	t.Run("empty url", func(t *testing.T) {
+		if os.Getenv(requestURLEnvKey) != "" {
+			panic(fmt.Sprintf("expected %v to be empty", requestURLEnvKey))
+		}
+
+		_, err := NewOIDCClient()
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if want, got := (&errURLError{}), err; !errors.As(got, &want) {
+			t.Fatalf("unexpected error, want: %#v, got: %#v", want, got)
+		}
+	})
 }
 
 func TestToken(t *testing.T) {

--- a/github/oidctest.go
+++ b/github/oidctest.go
@@ -118,20 +118,19 @@ func newTestOIDCServer(t *testing.T, now time.Time, f http.HandlerFunc) (*httpte
 	}))
 	issuerURL = s.URL
 
-	c, err := NewOIDCClient()
+	requestURL, err := url.ParseRequestURI(s.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	c.requestURL, err = url.Parse(s.URL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	c.verifierFunc = func(ctx context.Context) (*oidc.IDTokenVerifier, error) {
-		return oidc.NewVerifier(s.URL, &testKeySet{}, &oidc.Config{
-			Now:               func() time.Time { return now },
-			SkipClientIDCheck: true,
-		}), nil
+	c := OIDCClient{
+		requestURL: requestURL,
+		verifierFunc: func(ctx context.Context) (*oidc.IDTokenVerifier, error) {
+			return oidc.NewVerifier(s.URL, &testKeySet{}, &oidc.Config{
+				Now:               func() time.Time { return now },
+				SkipClientIDCheck: true,
+			}), nil
+		},
 	}
 
-	return s, c
+	return s, &c
 }


### PR DESCRIPTION
`net/url.Parse` does not return an error when the url is empty so `OIDCClient` gets all the way to fetching a token with a URL like `?audience=...` before failing.

This PR changes it so that creating the OIDC client fails when the `ACTIONS_ID_TOKEN_REQUEST_URL` environment variable is empty with a (hopefully) better error message.