### PR TITLE
Fix reading github context in detect-workflow

### DIFF
--- a/.github/actions/detect-workflow/action.yml
+++ b/.github/actions/detect-workflow/action.yml
@@ -24,5 +24,3 @@ outputs:
 runs:
   using: "docker"
   image: "Dockerfile"
-  env:
-    GITHUB_CONTEXT: "${{ toJSON(github) }}"

--- a/.github/actions/detect-workflow/action.yml
+++ b/.github/actions/detect-workflow/action.yml
@@ -24,3 +24,5 @@ outputs:
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    GITHUB_CONTEXT: "${{ toJSON(github) }}"

--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -33,6 +33,8 @@ type action struct {
 	client *github.OIDCClient
 }
 
+// TODO(github.com/slsa-framework/slsa-github-generator/issues/153): use go-githubactions
+
 func newAction(getenv func(string) string, c *github.OIDCClient) (*action, error) {
 	eventPath := getenv("GITHUB_EVENT_PATH")
 	if eventPath == "" {

--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -33,7 +33,7 @@ type action struct {
 	client *github.OIDCClient
 }
 
-// TODO(github.com/slsa-framework/slsa-github-generator/issues/153): use go-githubactions
+// TODO(github.com/slsa-framework/slsa-github-generator/issues/164): use the github context via the shared library
 
 func newAction(getenv func(string) string, c *github.OIDCClient) (*action, error) {
 	eventPath := getenv("GITHUB_EVENT_PATH")

--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -16,23 +16,55 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"path"
 	"strings"
 
 	"github.com/slsa-framework/slsa-github-generator/github"
 )
 
-// getStr returns a string value from the given Event map. Values are specified
+type action struct {
+	getenv func(string) string
+	event  map[string]any
+	client *github.OIDCClient
+}
+
+func newAction(getenv func(string) string, c *github.OIDCClient) (*action, error) {
+	eventPath := getenv("GITHUB_EVENT_PATH")
+	if eventPath == "" {
+		return nil, errors.New("GITHUB_EVENT_PATH not set")
+	}
+
+	payload, err := os.ReadFile(eventPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var event map[string]any
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return nil, err
+	}
+
+	return &action{
+		getenv: getenv,
+		event:  event,
+		client: c,
+	}, nil
+}
+
+// getEventValue returns a string value from the given Event map. Values are specified
 // as dot-separated indexes into the map. e.g.
 // "pull_request.head.repo.full_name".
-func getStr(m map[string]interface{}, key string) string {
+func (a *action) getEventValue(key string) string {
 	if key == "" {
 		return ""
 	}
 
+	m := a.event
 	parts := strings.Split(key, ".")
 
 	// Traverse the first parts of the path.
@@ -57,27 +89,23 @@ func getStr(m map[string]interface{}, key string) string {
 	}
 }
 
-func getRepoRef(ctx context.Context, c *github.OIDCClient) (string, string, error) {
+func (a *action) getRepoRef(ctx context.Context) (string, string, error) {
 	var repository, ref string
 
-	ghContext, err := github.GetWorkflowContext()
-	if err != nil {
-		return "", "", fmt.Errorf("getting github context: %w", err)
-	}
-
 	// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove special logic for pull_requests.
-	if ghContext.EventName == "pull_request" {
+	eventName := a.getenv("GITHUB_EVENT_NAME")
+	if eventName == "pull_request" {
 		// If a pull request get the repo from the pull request.
-		repository = getStr(ghContext.Event, "pull_request.head.repo.full_name")
-		ref = ghContext.HeadRef
+		repository = a.getEventValue("pull_request.head.repo.full_name")
+		ref = a.getenv("GITHUB_HEAD_REF")
 	} else {
-		audience := ghContext.Repository
+		audience := a.getenv("GITHUB_REPOSITORY")
 		if audience == "" {
 			return "", "", errors.New("missing github repository context")
 		}
 		audience = path.Join(audience, "detect-workflow")
 
-		t, err := c.Token(ctx, []string{audience})
+		t, err := a.client.Token(ctx, []string{audience})
 		if err != nil {
 			return "", "", fmt.Errorf("getting OIDC token: %w", err)
 		}
@@ -103,7 +131,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	repository, ref, err := getRepoRef(context.Background(), c)
+	a, err := newAction(os.Getenv, c)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	repository, ref, err := a.getRepoRef(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fix the detect-workflow action to get the github context from environment variables. The `github` context is not available in `actions.yml` so we can't use it as we have with reusable workflows.

We should consider using go-githubactions (#153) to get and manage the context as it will work within both actions and reusable workflows.