### PR TITLE
🐛 Always include context fields

### DIFF
--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -84,9 +84,9 @@ func (b *GithubActionsBuild) BuildConfig(context.Context) (interface{}, error) {
 }
 
 func addEnvKeyString(m map[string]interface{}, k string, v string) {
-	if v != "" {
-		m[k] = v
-	}
+	// Always record the value, even if it's empty. Let
+	// the consumer/verifier decide how to interpret the meaning.
+	m[k] = v
 }
 
 // getEntryPoint retrieves the path to the user workflow that initiated the

--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -85,7 +85,7 @@ func (b *GithubActionsBuild) BuildConfig(context.Context) (interface{}, error) {
 
 func addEnvKeyString(m map[string]interface{}, k string, v string) {
 	// Always record the value, even if it's empty. Let
-	// the consumer/verifier decide how to interpret the meaning.
+	// the consumer/verifier decide how to interpret their meaning.
 	m[k] = v
 }
 

--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -204,9 +204,8 @@ func (b *GithubActionsBuild) Invocation(ctx context.Context) (slsa.ProvenanceInv
 		addEnvKeyString(env, "github_repository_owner_id", t.RepositoryOwnerID)
 	}
 
-	if len(env) > 0 {
-		i.Environment = env
-	}
+	// Set the env.
+	i.Environment = env
 
 	// ConfigSource
 	entryPoint, err := b.getEntryPoint(ctx)

--- a/slsa/provenance_test.go
+++ b/slsa/provenance_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/slsa-framework/slsa-github-generator/github"
 )
 
-var testBuildType = "http://example.com/v1"
-var testBuildConfig = "test build config"
+var (
+	testBuildType   = "http://example.com/v1"
+	testBuildConfig = "test build config"
+)
 
 type TestBuild struct {
 	*GithubActionsBuild
@@ -55,16 +57,39 @@ func TestHostedActionsProvenance(t *testing.T) {
 					},
 					BuildType:   testBuildType,
 					BuildConfig: testBuildConfig,
-					Metadata:    &slsa.ProvenanceMetadata{},
+					Invocation: slsa.ProvenanceInvocation{
+						Environment: map[string]interface{}{
+							"github_run_id":           "",
+							"github_run_attempt":      "",
+							"github_actor":            "",
+							"github_base_ref":         "",
+							"github_event_name":       "",
+							"github_head_ref":         "",
+							"github_ref":              "",
+							"github_ref_type":         "",
+							"github_repository_owner": "",
+							"github_run_number":       "",
+							"github_sha1":             "",
+						},
+					},
+					Metadata: &slsa.ProvenanceMetadata{},
 				},
 			},
 		},
 		{
-			name: "invocation id",
+			name: "invocation env",
 			b: &TestBuild{
 				GithubActionsBuild: NewGithubActionsBuild(nil, github.WorkflowContext{
 					RunID:      "12345",
 					RunAttempt: "1",
+					EventName:  "pull_request",
+					SHA:        "abcde",
+					RefType:    "branch",
+					Ref:        "some/ref",
+					BaseRef:    "some/base_ref",
+					HeadRef:    "some/head_ref",
+					RunNumber:  "102937",
+					Actor:      "user",
 				}).WithClients(&NilClientProvider{}),
 			},
 			token: &github.OIDCToken{
@@ -84,8 +109,22 @@ func TestHostedActionsProvenance(t *testing.T) {
 					BuildConfig: testBuildConfig,
 					Invocation: slsa.ProvenanceInvocation{
 						Environment: map[string]interface{}{
-							"github_run_id":      "12345",
-							"github_run_attempt": "1",
+							"github_run_id":           "12345",
+							"github_run_attempt":      "1",
+							"github_actor":            "user",
+							"github_base_ref":         "some/base_ref",
+							"github_event_name":       "pull_request",
+							"github_head_ref":         "some/head_ref",
+							"github_ref":              "some/ref",
+							"github_ref_type":         "branch",
+							"github_repository_owner": "",
+							"github_run_number":       "102937",
+							"github_sha1":             "abcde",
+						},
+						ConfigSource: slsa.ConfigSource{
+							Digest: slsa.DigestSet{
+								"sha1": "abcde",
+							},
 						},
 					},
 					Metadata: &slsa.ProvenanceMetadata{


### PR DESCRIPTION
The verifier expects all fields to be populated, even if they are empty. (see https://github.com/slsa-framework/slsa-verifier/blob/main/pkg/provenance.go#L596)

We did not catch this via the pre-submits because it's only triggered on push/tag events; and we can only tests these thoroughly in the e2e tests.

This PR should fix https://github.com/slsa-framework/slsa-github-generator/issues/159 and https://github.com/slsa-framework/slsa-github-generator/issues/156