### PR TITLE
Add linter pre-submits

### DIFF
--- a/.github/workflows/pre-submit.reviewdog.yml
+++ b/.github/workflows/pre-submit.reviewdog.yml
@@ -1,0 +1,42 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          go_version: "1.18"
+          golangci_lint_flags: "--timeout=5m"
+          level: warning
+          fail_on_error: true
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          level: warning
+          fail_on_error: true
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: shfmt
+        uses: reviewdog/action-shfmt@v1
+        with:
+          level: warning
+          fail_on_error: true
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: yamllint
+        uses: reviewdog/action-yamllint@v1
+        with:
+          yamllint_flags: "-c .yamllint.config.yaml ."
+          level: warning
+          fail_on_error: true

--- a/.yamllint.config.yaml
+++ b/.yamllint.config.yaml
@@ -1,0 +1,6 @@
+---
+rules:
+  line-length: disable
+  comments:
+    # prettier formats comments one space from content
+    min-spaces-from-content: 1


### PR DESCRIPTION
Fixes #53

Adds pre-submits that run linters over code and add review comments to PRs.

- golangci-lint for Go code (note that many linters are disabled due to not supporting Go 1.18 - https://github.com/golangci/golangci-lint/issues/2649)
- shellcheck and shfmt for shell code.
- yamllint for yaml