### PR TITLE
fix: require binary upload before binary download

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -433,7 +433,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [build, build-dry, provenance]
+    needs: [build, build-dry, binary-upload, provenance]
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       # Verify binary hash.


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This is causing me failures: https://github.com/asraa/slsa-example/actions/runs/2502778013

[build / upload-assets](https://github.com/asraa/slsa-example/runs/6901412245?check_suite_focus=true#step:2:16)
Unable to find an artifact with the name: binary-linux-amd64

This is because binary-upload is not required for the upload-assets job.