### PR TITLE
🐛 Ref name update

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -111,7 +111,7 @@ jobs:
         id: builder-gen
         env:
           COMPILE_BUILDER: "${{ inputs.compile-builder }}"
-          BUILDER_REF: "${{ needs.detect-env.outputs.builder_ref }}"
+          BUILDER_REF: "${{ needs.detect-env.outputs.ref }}"
           # Needed for the gh CLI used in builder-fetch.sh.
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |


### PR DESCRIPTION
A ref was not updated, resulting in:
```
Fetching the builder with ref: 
Builder referenced by hash: 
Resolving...
Tag not found for 
```

when using the pre-built builder binary. I caught this during the pre-release test