### PR TITLE
Refactor - Use interface for rekor and fulcio

### DIFF
--- a/internal/builders/go/main.go
+++ b/internal/builders/go/main.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/slsa-framework/slsa-github-generator/signing/sigstore"
+
 	// Enable the github OIDC auth provider.
 	_ "github.com/sigstore/cosign/pkg/providers/github"
 
@@ -72,8 +74,10 @@ func runBuild(dry bool, configFile, evalEnvs string) error {
 }
 
 func runProvenanceGeneration(subject, digest, commands, envs, workingDir string) error {
+	r := sigstore.NewDefaultRekor()
+	s := sigstore.NewDefaultFulcio()
 	attBytes, err := pkg.GenerateProvenance(subject, digest,
-		commands, envs, workingDir)
+		commands, envs, workingDir, s, r)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/slsa-framework/slsa-github-generator/signing"
+
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/slsa-framework/slsa-github-generator/github"
 	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/signing/sigstore"
 	"github.com/slsa-framework/slsa-github-generator/slsa"
 )
 
@@ -63,7 +64,7 @@ func (b *goProvenanceBuild) BuildConfig(context.Context) (interface{}, error) {
 // GenerateProvenance translates github context into a SLSA provenance
 // attestation.
 // Spec: https://slsa.dev/provenance/v0.2
-func GenerateProvenance(name, digest, command, envs, workingDir string) ([]byte, error) {
+func GenerateProvenance(name, digest, command, envs, workingDir string, s signing.Signer, r signing.TransparencyLog) ([]byte, error) {
 	gh, err := github.GetWorkflowContext()
 	if err != nil {
 		return nil, err
@@ -153,7 +154,6 @@ func GenerateProvenance(name, digest, command, envs, workingDir string) ([]byte,
 	}
 
 	// Sign the provenance.
-	s := sigstore.NewDefaultFulcio()
 	att, err := s.Sign(ctx, &intoto.Statement{
 		StatementHeader: p.StatementHeader,
 		Predicate:       p.Predicate,
@@ -163,7 +163,6 @@ func GenerateProvenance(name, digest, command, envs, workingDir string) ([]byte,
 	}
 
 	// Upload the signed attestation to rekor.
-	r := sigstore.NewDefaultRekor()
 	if logEntry, err := r.Upload(ctx, att); err != nil {
 		fmt.Printf("Uploaded signed attestation to rekor with UUID %s.\n", logEntry.UUID())
 		return nil, err


### PR DESCRIPTION
- Refactored the implementation to accept the interface instead of the
  concrete implementation within the function.

- With this change `GenerateProvenance` can be tested with mocks. At the
  moment there aren't any unit tests for `GenerateProvenance`.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
