### PR TITLE
Add release configs for the generic generator

### DIFF
--- a/.github/workflows/configs-generic/config-release.yml
+++ b/.github/workflows/configs-generic/config-release.yml
@@ -1,0 +1,14 @@
+# Used for pre-submit tests.
+version: 1
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+
+flags:
+  - -trimpath
+  - -tags=netgo
+
+goos: linux
+goarch: amd64
+dir: internal/builders/generic/
+binary: slsa-generator-generic-{{ .Os }}-{{ .Arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,18 @@ on:
 permissions: read-all
 
 jobs:
+  # Generic generator.
+  generic-generator:
+    permissions:
+      id-token: write # For signing.
+      contents: write # For asset uploads.
+      actions: read # For the entrypoint.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@main
+    with:
+      go-version: 1.18
+      config-file: .github/workflows/configs-generic/config-release.yml
+      compile-builder: true
+
   # Go builder.
   go-builder:
     permissions:


### PR DESCRIPTION
@laurentsimon 

Following the pattern of the Go builder and [RELEASE.md](https://github.com/slsa-framework/slsa-github-generator/blob/main/RELEASE.md) docs.

My understanding is that after I add these configs, I can cut a release which will include the generic generator's binary, and then I can use that to speed up the workflow.

Updates #177 