### PR TITLE
🐛 Release sequentially

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
 
   # Go builder.
   go-builder:
+    # Force the builds to rin sequentially, to avoid
+    # the builder binaries being overwritten by each run.
+    needs: [generic-generator]
     permissions:
       id-token: write # For signing.
       contents: write # For asset uploads.


### PR DESCRIPTION
The two builds are still colliding on their name are the same. This PR forces each build to run sequentially.

We will fix this once we have multi-build support for Go builder