### PR TITLE
chore: bump verifier to new version

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -27,8 +27,8 @@ env:
   # Verifier
   VERIFIER_REPOSITORY: slsa-framework/slsa-verifier
   VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64
-  VERIFIER_RELEASE_BINARY_SHA256: 60c91c9d5b9a059e37ac46da316f20c81da335b5d00e1f74d03dd50f819694bd
-  VERIFIER_RELEASE: v0.0.1
+  VERIFIER_RELEASE_BINARY_SHA256: 14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53
+  VERIFIER_RELEASE: v1.1.0
   # Builder location
   BUILDER_DIR: internal/builders
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Verify this hash by:

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout v1.1.0)
$ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.0
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```