### PR TITLE
Return an error if repo/ref not detected

### DIFF
--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -46,8 +46,6 @@ func newAction(getenv func(string) string, c *github.OIDCClient) (*action, error
 		return nil, err
 	}
 
-	log.Printf("event: %s", payload)
-
 	var event map[string]any
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return nil, err

--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -46,6 +46,8 @@ func newAction(getenv func(string) string, c *github.OIDCClient) (*action, error
 		return nil, err
 	}
 
+	log.Printf("event: %s", payload)
+
 	var event map[string]any
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return nil, err
@@ -123,6 +125,13 @@ func (a *action) getRepoRef(ctx context.Context) (string, string, error) {
 			return "", "", errors.New("missing reference in job workflow ref")
 		}
 		ref = refParts[1]
+	}
+
+	if repository == "" {
+		return "", "", errors.New("no repository detected")
+	}
+	if ref == "" {
+		return "", "", errors.New("no ref detected")
 	}
 
 	return repository, ref, nil

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -61,8 +61,7 @@ jobs:
     steps:
       - name: Detect the generator ref
         id: detect
-        # uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@bbeae84f20f78877b7ba56f324b993c3ee576cf1
-        uses: ianlewis/slsa-github-generator/.github/actions/detect-workflow@detect-env-empty-outputs
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@bbeae84f20f78877b7ba56f324b993c3ee576cf1
 
   ###################################################################
   #                                                                 #

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -61,7 +61,8 @@ jobs:
     steps:
       - name: Detect the generator ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@bbeae84f20f78877b7ba56f324b993c3ee576cf1
+        # uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@bbeae84f20f78877b7ba56f324b993c3ee576cf1
+        uses: ianlewis/slsa-github-generator/.github/actions/detect-workflow@detect-env-empty-outputs
 
   ###################################################################
   #                                                                 #


### PR DESCRIPTION
Related #376

I'm not sure why but it seems that in `pull_requests` (even though we don't really support them, and possibly other triggers) sometimes the `detect-workflow` action returns empty strings in the repository and/or ref outputs without producing an error. If fed directly into a later `checkout` action this checks out the repository in the `github` context (not the slsa-github-generator) repo.

This PR causes the `detect-workflow` action to return an error if no repository or ref are found.