### PR TITLE
Refactor Println to use a stream

### DIFF
--- a/internal/builders/go/main.go
+++ b/internal/builders/go/main.go
@@ -55,7 +55,7 @@ func runBuild(dry bool, configFile, evalEnvs string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(cfg)
+	fmt.Fprintln(pkg.Output, cfg)
 
 	gobuild := pkg.GoBuildNew(goc, cfg)
 
@@ -142,7 +142,7 @@ func main() {
 		check(err)
 
 	default:
-		fmt.Println("expected 'build' or 'provenance' subcommands")
+		fmt.Fprintln(pkg.Output, "expected 'build' or 'provenance' subcommands")
 		os.Exit(1)
 	}
 }

--- a/internal/builders/go/pkg/build.go
+++ b/internal/builders/go/pkg/build.go
@@ -52,6 +52,8 @@ var allowedEnvVariablePrefix = map[string]bool{
 	"GO": true, "CGO_": true,
 }
 
+var Output = os.Stdout
+
 type GoBuild struct {
 	cfg *GoReleaserConfig
 	goc string
@@ -155,10 +157,10 @@ func (b *GoBuild) Run(dry bool) error {
 		return err
 	}
 
-	fmt.Println("dir", dir)
-	fmt.Println("binary", binary)
-	fmt.Println("command", command)
-	fmt.Println("env", envs)
+	fmt.Fprintf(Output, "dir %s \n", dir)
+	fmt.Fprintf(Output, "binary %s \n", binary)
+	fmt.Fprintf(Output, "command %s \n", command)
+	fmt.Fprintf(Output, "env %s \n", envs)
 
 	return syscall.Exec(b.goc, command, envs)
 }


### PR DESCRIPTION
The default Println writes to stdout which makes it harder to test.

Refactored to write to `stdout` but configured with a variable which can
be updated for tests.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
