### PR TITLE
Update actions ref

### DIFF
--- a/.github/actions/checkout-go/action.yml
+++ b/.github/actions/checkout-go/action.yml
@@ -1,24 +1,24 @@
-name: 'Checkout a repository for a Go project'
-description: 'Checkout and setup the environment for a Go project'
+name: "Checkout a repository for a Go project"
+description: "Checkout and setup the environment for a Go project"
 inputs:
   repository:
-    description: 'Repository name with owner.'
+    description: "Repository name with owner."
     required: false
     # Same default as https://github.com/actions/checkout/blob/main/action.yml#L6.
     default: ${{ github.repository }}
   ref:
-    # Note: the logic is fairly involved https://github.com/actions/checkout/blob/main/src/ref-helper.ts, 
+    # Note: the logic is fairly involved https://github.com/actions/checkout/blob/main/src/ref-helper.ts,
     # so we do not attempt to resolve it ourselves or provide a default value. We let the official `actions/checkout`
     # do it for us.
-    description: 'The branch, tag or SHA to checkout.'
+    description: "The branch, tag or SHA to checkout."
     required: false
   token:
-    description: 'The token to use.'
+    description: "The token to use."
     required: false
     # Same default as https://github.com/actions/checkout/blob/main/action.yml#L24.
     default: ${{ github.token }}
   go-version:
-    description: 'The Go version to use, as expected by https://github.com/actions/setup-go.'
+    description: "The Go version to use, as expected by https://github.com/actions/setup-go."
     required: true
 
 runs:

--- a/.github/actions/compute-sha256/action.yml
+++ b/.github/actions/compute-sha256/action.yml
@@ -1,12 +1,12 @@
-name: 'SHA256 of a file'
-description: 'Compute the SHA256 of a file'
+name: "SHA256 of a file"
+description: "Compute the SHA256 of a file"
 inputs:
   path:
-    description: 'Path to a file.'
+    description: "Path to a file."
     required: true
 outputs:
   sha256:
-    description: 'The SHA256 of the file.'
+    description: "The SHA256 of the file."
     value: "${{ steps.compute.outputs.sha256 }}"
 
 runs:
@@ -17,4 +17,3 @@ runs:
       env:
         UNTRUSTED_PATH: "${{ inputs.path }}"
       run: ./.github/actions/compute-sha256.sh
-

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -52,7 +52,7 @@ runs:
       run: ./.github/actions/generate-builder/generate-builder.sh
 
     - name: Compute sha256 of builder
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha@fe4b511143bc6fb575303b60d4361decbe5a2df3
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@fe4b511143bc6fb575303b60d4361decbe5a2df3
       id: compute
       with:
         path: "${{ inputs.binary }}"

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -1,45 +1,45 @@
-name: 'Generate the builder'
-description: 'Build or fetch the builder binary'
+name: "Generate the builder"
+description: "Build or fetch the builder binary"
 inputs:
   ref:
-    description: 'Ref of the builder.'
+    description: "Ref of the builder."
     required: true
   repository:
-    description: 'Repository of the builder.'
+    description: "Repository of the builder."
     required: true
   binary:
-    description: 'Name of the compiled binary. (Note: just the filename, not the path)'
+    description: "Name of the compiled binary. (Note: just the filename, not the path)"
     required: true
   compile-builder:
-    description: 'Whether to compile the builder or not.'
+    description: "Whether to compile the builder or not."
     required: true
   directory:
-    description: 'Directory of the source code of the builder. (Note: expect no trailing `/`)'
+    description: "Directory of the source code of the builder. (Note: expect no trailing `/`)"
     required: true
   go-version:
-    description: 'The Go version to use, as expected by https://github.com/actions/setup-go.'
+    description: "The Go version to use, as expected by https://github.com/actions/setup-go."
     required: true
 
   token:
-    description: 'GitHub token'
+    description: "GitHub token"
     required: false
     default: ${{ github.token }}
 
 outputs:
   sha256:
-    description: 'SHA256 of the builder binary.'
+    description: "SHA256 of the builder binary."
     value: ${{ steps.compute.outputs.sha256 }}
 
 runs:
   using: "composite"
   steps:
     - name: Checkout the Go builder repository
-      uses: ./.github/actions/checkout-go
+      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fe4b511143bc6fb575303b60d4361decbe5a2df3
       with:
         repository: "${{ inputs.repository }}"
         ref: "${{ inputs.ref }}"
         go-version: "${{ inputs.go-version }}"
-    
+
     - name: Generate builder
       shell: bash
       env:
@@ -50,9 +50,9 @@ runs:
         # Needed for the gh CLI used in builder-fetch.sh.
         GH_TOKEN: "${{ inputs.token }}"
       run: ./.github/actions/generate-builder/generate-builder.sh
-    
+
     - name: Compute sha256 of builder
-      uses: ./.github/actions/compute-sha256
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha@fe4b511143bc6fb575303b60d4361decbe5a2df3
       id: compute
       with:
         path: "${{ inputs.binary }}"

--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Compute the hash
       id: compute
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha@fe4b511143bc6fb575303b60d4361decbe5a2df3
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@fe4b511143bc6fb575303b60d4361decbe5a2df3
       with:
         path: "${{ inputs.name }}"
 

--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -1,17 +1,17 @@
-name: 'Secure artifact download'
-description: 'Download an artifact and verify its SHA256'
+name: "Secure artifact download"
+description: "Download an artifact and verify its SHA256"
 inputs:
   name:
-    description: 'Artifact name.'
+    description: "Artifact name."
     required: true
   path:
-    description: 'Destination path.'
+    description: "Destination path."
     required: false
   sha256:
-    description: 'SHA256 of the file for verification.'
+    description: "SHA256 of the file for verification."
     required: true
   set-executable:
-    description: 'Set the artifact as executable.'
+    description: "Set the artifact as executable."
     required: false
 
 runs:
@@ -21,10 +21,10 @@ runs:
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: "${{ inputs.name }}"
-    
+
     - name: Compute the hash
       id: compute
-      uses: ./.github/actions/compute-sha256
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha@fe4b511143bc6fb575303b60d4361decbe5a2df3
       with:
         path: "${{ inputs.name }}"
 

--- a/.github/workflows/pre-submit.e2e.generic.default.yml
+++ b/.github/workflows/pre-submit.e2e.generic.default.yml
@@ -1,7 +1,9 @@
 name: pre-submit e2e generic default
 on:
-  pull_request:
-    branches: [main]
+  # TODO(github.com/slsa-framework/slsa-github-generator/issues/452): restore pre-submit
+  # pull_request:
+  #   branches: [main]
+  workflow_dispatch:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-submit.e2e.go.config-ldflags-main-dir.yml
+++ b/.github/workflows/pre-submit.e2e.go.config-ldflags-main-dir.yml
@@ -1,7 +1,9 @@
 name: Pre-submit e2e go ldflags main dir
 on:
-  pull_request:
-    branches: [main]
+  # TODO(github.com/slsa-framework/slsa-github-generator/issues/452): restore pre-submit
+  # pull_request:
+  #   branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Updates #452 

Updates references in re-usable actions to point to a repository sha and not require a checkout of the repository.

We will need to reference re-usable actions in our workflow pre-submits after this PR is merged so workflow pre-submits are disabled by the PR temporarily. They will be re-enabled in subsequent PR #453

NOTE: The "verify" required status check was removed from the repository branch protection rules to allow us to commit this PR. This will also be restored for #453 