### PR TITLE
Update references to reusable actions.

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the Go builder repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@49e648aa7f5f4f88513b6cd54f6b189516184e6b
       with:
         repository: "${{ inputs.repository }}"
         ref: "${{ inputs.ref }}"
@@ -52,7 +52,7 @@ runs:
       run: ./.github/actions/generate-builder/generate-builder.sh
 
     - name: Compute sha256 of builder
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@49e648aa7f5f4f88513b6cd54f6b189516184e6b
       id: compute
       with:
         path: "${{ inputs.binary }}"

--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Compute the hash
       id: compute
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@49e648aa7f5f4f88513b6cd54f6b189516184e6b
       with:
         path: "${{ inputs.name }}"
 

--- a/.github/actions/secure-upload-artifact/action.yml
+++ b/.github/actions/secure-upload-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Compute binary hash
       id: compute-digest
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@49e648aa7f5f4f88513b6cd54f6b189516184e6b
       with:
         path: "${{ inputs.path }}"
 

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@d995948e8d53cc639c0d3ef69db31dbc243519c4 # v1.1.1
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@49e648aa7f5f4f88513b6cd54f6b189516184e6b # v1.1.1
 
   ###################################################################
   #                                                                 #
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Generate builder
         id: generate
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -128,12 +128,12 @@ jobs:
     needs: builder
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           go-version: ${{ inputs.go-version }}
 
       - name: Download builder
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ env.BUILDER_BINARY }}"
           sha256: "${{ needs.builder.outputs.go-builder-sha256 }}"
@@ -165,12 +165,12 @@ jobs:
     needs: [builder, build-dry]
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           go-version: ${{ inputs.go-version }}
 
       - name: Download builder
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ env.BUILDER_BINARY }}"
           sha256: "${{ needs.builder.outputs.go-builder-sha256 }}"
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload generated binary
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           path: "${{ needs.build-dry.outputs.go-binary-name }}"
 
@@ -235,7 +235,7 @@ jobs:
       go-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}
     steps:
       - name: Download builder
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ env.BUILDER_BINARY }}"
           sha256: "${{ needs.builder.outputs.go-builder-sha256 }}"
@@ -286,13 +286,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - name: Download binary
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ needs.build-dry.outputs.go-binary-name }}"
           sha256: "${{ needs.builder.outputs.go-builder-sha256 }}"
 
       - name: Download provenance
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ needs.provenance.outputs.go-provenance-name }}"
           sha256: "${{ needs.provenance.outputs.go-provenance-sha256 }}"

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Detect the generator ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@d995948e8d53cc639c0d3ef69db31dbc243519c4 # v1.1.1
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@49e648aa7f5f4f88513b6cd54f6b189516184e6b # v1.1.1
 
   # generator builds the generator binary and runs it to generate SLSA
   # provenance.
@@ -93,7 +93,7 @@ jobs:
       actions: read
     steps:
       - name: Generate builder
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -141,7 +141,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-to-release == true
     steps:
       - name: Download the provenance
-        uses: slsa-framework/slsa-github-generator/.github/actions/download-artifact@1b4ebe8029b40670c71aae9b9c88be486beb6b49
+        uses: slsa-framework/slsa-github-generator/.github/actions/download-artifact@49e648aa7f5f4f88513b6cd54f6b189516184e6b
         with:
           name: "${{ needs.generator.outputs.attestation-name }}"
           sha256: "${{ needs.generator.outputs.attestation-sha256 }}"


### PR DESCRIPTION
Updates all references to internal actions.

This command did the trick (at least for now).
```
find .github/ -name '*.yaml' -o -name '*.yml' | xargs sed -i 's/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@[a-f0-9]*/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@49e648aa7f5f4f88513b6cd54f6b189516184e6b/'
```