### PR TITLE
Add BUILDER_DIR to generic workflow

### DIFF
--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -29,6 +29,8 @@ env:
   VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64
   VERIFIER_RELEASE_BINARY_SHA256: f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21
   VERIFIER_RELEASE: v1.1.1
+  # Builder location
+  BUILDER_DIR: internal/builders
 
 on:
   workflow_call:


### PR DESCRIPTION
The `BUILDER_DIR` environment variable was never added to the generic workflow in #438 

Fixes the following error:
`./.github/actions/generate-builder/generate-builder.sh: line 7: cd: /generic: No such file or directory`