### PR TITLE
Add builder as dependency of upload-assets

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -282,7 +282,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [build-dry, build, provenance]
+    needs: [builder, build-dry, build, provenance]
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - name: Download binary

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -282,14 +282,14 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [builder, build-dry, build, provenance]
+    needs: [build-dry, build, provenance]
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - name: Download binary
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@ab345b0851aceba69a2ce8f3d2084f6e7d887850
         with:
           name: "${{ needs.build-dry.outputs.go-binary-name }}"
-          sha256: "${{ needs.builder.outputs.go-builder-sha256 }}"
+          sha256: "${{ needs.build.outputs.go-binary-sha256 }}"
 
       - name: Download provenance
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@ab345b0851aceba69a2ce8f3d2084f6e7d887850


### PR DESCRIPTION
Updates #469 

Fixes "hashes do not match" error when running the Go workflow. This adds the `builder` job as a dependency for `upload-assets` so that the outputs from `builder` can be used.