### PR TITLE
Add additional guidance for users who don't pin by tag

### DIFF
--- a/.github/actions/generate-builder/builder-fetch.sh
+++ b/.github/actions/generate-builder/builder-fetch.sh
@@ -52,7 +52,8 @@ if [[ "$BUILDER_TAG" == "$(echo -n "$BUILDER_TAG" | grep -P '^[a-f\d]{40}$')" ]]
 fi
 
 if [[ "$BUILDER_TAG" != "$(echo -n "$BUILDER_TAG" | grep -P '^v\d*(\.([\d]{1,})){0,2}$')" ]]; then
-    echo "Invalid version: $BUILDER_TAG. Expected version of the form vX.Y.Z"
+    echo "Invalid builder version: $BUILDER_TAG. Expected version of the form vX.Y.Z"
+    echo "For details see https://github.com/slsa-framework/slsa-github-generator#verification-of-provenance"
     exit 7
 fi
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ This is a pre-release only and we will have the official release in July 2022.
 
 To verify the provenance, use the [github.com/slsa-framework/slsa-verifier](https://github.com/slsa-framework/slsa-verifier) project.
 
+**Note**: At present the GitHub Actions provided in this repository as builders and generators MUST be referenced by tag in order for the slsa-verifier to be able to verify the ref of the trusted builder/generator's reusable workflow.
+
+This is contrary to the [best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) which recommends referencing by digest.
+The desire to be able to verify reusable workflows pinned by hash, and the reasons for the current status, are tracked as [Issue #12](https://github.com/slsa-framework/slsa-verifier/issues/12) in the slsa-verifier project.
+
 ### Installation
 
 To install the verifier, see [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).


### PR DESCRIPTION
Adds some documentation on why slsa-verifier requires we pin by tag to the README and points users to that section of the README when fetching the builder fails.

Fixes #431