### PR TITLE
Port the sha256 shell to go code

### DIFF
--- a/.github/actions/compute-sha256/Dockerfile
+++ b/.github/actions/compute-sha256/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 SLSA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang@sha256:a452d6273ad03a47c2f29b898d6bb57630e77baf839651ef77d03e4e049c5bf3 as builder
+
+WORKDIR /app
+COPY . /app
+
+RUN go get -d -v
+
+# Statically compile our app for use in a distroless container
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -v -o app .
+
+# A distroless container image with some basics like SSL certificates
+# https://github.com/GoogleContainerTools/distroless
+FROM gcr.io/distroless/static@sha256:2ad95019a0cbf07e0f917134f97dd859aaccc09258eb94edcb91674b3c1f448f
+
+COPY --from=builder /app/app /app
+
+ENTRYPOINT ["/app"]

--- a/.github/actions/compute-sha256/action.yml
+++ b/.github/actions/compute-sha256/action.yml
@@ -10,21 +10,5 @@ outputs:
     value: "${{ steps.compute.outputs.sha256 }}"
 
 runs:
-  using: "composite"
-  steps:
-    - name: Compute the sha256
-      id: compute
-      shell: bash
-      env:
-        UNTRUSTED_PATH: "${{ inputs.path }}"
-      run: |
-        set -euo pipefail
-        echo "Computing SHA256 for $UNTRUSTED_PATH"
-        if [[ ! -f "$UNTRUSTED_PATH" ]]; then
-            echo "File $UNTRUSTED_PATH not present"
-            exit 5
-        fi
-        digest=$(sha256sum "$UNTRUSTED_PATH" | awk '{print $1}')
-        echo "computed sha: $digest"
-        
-        echo "::set-output name=sha256::$digest"
+  using: "docker"
+  image: "Dockerfile"

--- a/.github/actions/compute-sha256/go.mod
+++ b/.github/actions/compute-sha256/go.mod
@@ -1,0 +1,3 @@
+module github.com/slsa-framework/slsa-github-generator/.github/actions/compute-sha256
+
+go 1.18

--- a/.github/actions/compute-sha256/main.go
+++ b/.github/actions/compute-sha256/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Println("Usage: sha256sum <file>")
+		panic("missing argument: path to the file to compute the SHA256 hash")
+	}
+
+	file := os.Args[1]
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		panic(fmt.Sprintf("file not found: %s", file))
+	}
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read file: %s", file))
+	}
+
+	hash := sha256.Sum256(data)
+	log.Printf("computed sha: %s\n", hex.EncodeToString(hash[:]))
+
+	cmd := exec.Command("/usr/bin/env", "bash", "-c",
+		"echo ::set-output name=sha256::"+hex.EncodeToString(hash[:]))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		panic(fmt.Sprintf("failed to set output: %s", err))
+	}
+}


### PR DESCRIPTION
The goal for this port from shell script to `go` was to reduce the
amount of shell script.

It is easier to refactor managed code compared to shell script.

This has been discussed https://github.com/slsa-framework/slsa-github-generator/issues/398

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>