### PR TITLE
feat: Input argument for the name of attestation of generic workflow

### DIFF
--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -37,7 +37,7 @@ on:
       attestation-name:
         description: >
           The artifact name of the signed provenance. 
-          The file must have the intoto.json extension.
+          The file must have the intoto.jsonl extension.
 
           Default: attestation.intoto.jsonl
         required: false
@@ -53,7 +53,7 @@ on:
         description: "The name of the release where provenance was uploaded."
         value: ${{ jobs.create-release.outputs.release-id }}
       attestation-name:
-        description: "The artifact name of the signed provenance. (A file with the intoto.json extension)."
+        description: "The artifact name of the signed provenance. (A file with the intoto.jsonl extension)."
         value: "${{ inputs.attestation-name }}"
 
 jobs:

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -114,7 +114,7 @@ jobs:
           # Note: The builder verifies that the UNTRUSTED_ATTESTATION_NAME is located
           # in the current directory.
           ./"$BUILDER_BINARY" attest --subjects "${SUBJECTS}" -g "$UNTRUSTED_ATTESTATION_NAME"
-          attestation_sha256=$(sha256sum $attestation_name | awk '{print $1}')
+          attestation_sha256=$(sha256sum "$UNTRUSTED_ATTESTATION_NAME" | awk '{print $1}')
           echo "::set-output name=attestation-sha256::$attestation_sha256"
 
       - name: Upload the signed provenance

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -38,7 +38,7 @@ on:
         description: "The artifact name of the signed provenance. (Default: attestation.intoto.jsonl)"
         required: false
         type: string
-        default: false
+        default: "attestation.intoto.jsonl"
       compile-generator:
         description: "Build the generator from source. This increases build time by ~2m."
         required: false

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: boolean
         default: false
+      attestation-name:
+        description: "The artifact name of the signed provenance. (Default: attestation.intoto.jsonl)"
+        required: false
+        type: string
+        default: false
       compile-generator:
         description: "Build the generator from source. This increases build time by ~2m."
         required: false
@@ -44,8 +49,8 @@ on:
         description: "The name of the release where provenance was uploaded."
         value: ${{ jobs.create-release.outputs.release-id }}
       attestation-name:
-        description: "The artifact name of the signed provenance"
-        value: ${{ jobs.generator.outputs.attestation-name }}
+        description: "The artifact name of the signed provenance."
+        value: "${{ inputs.attestation-name }}"
 
 jobs:
   # detect-env detects the reusable workflow's repository and ref for use later
@@ -73,7 +78,6 @@ jobs:
   # reference.
   generator:
     outputs:
-      attestation-name: ${{ steps.sign-prov.outputs.attestation-name }}
       attestation-sha256: ${{ steps.sign-prov.outputs.attestation-sha256 }}
     runs-on: ubuntu-latest
     needs: [detect-env]
@@ -103,21 +107,21 @@ jobs:
         env:
           SUBJECTS: "${{ inputs.base64-subjects }}"
           GITHUB_CONTEXT: "${{ toJSON(github) }}"
+          UNTRUSTED_ATTESTATION_NAME: "${{ inputs.attestation-name }}"
         run: |
           set -euo pipefail
-          # Create and sign provenance
-          # This sets attestation-name to the name of the signed DSSE envelope.
-          attestation_name="attestation.intoto.jsonl"
-          ./"$BUILDER_BINARY" attest --subjects "${SUBJECTS}" -g $attestation_name
+          # Create and sign provenance.
+          # Note: The builder verifies that the UNTRUSTED_ATTESTATION_NAME is located
+          # in the current directory.
+          ./"$BUILDER_BINARY" attest --subjects "${SUBJECTS}" -g "$UNTRUSTED_ATTESTATION_NAME"
           attestation_sha256=$(sha256sum $attestation_name | awk '{print $1}')
-          echo "::set-output name=attestation-name::$attestation_name"
           echo "::set-output name=attestation-sha256::$attestation_sha256"
 
       - name: Upload the signed provenance
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
         with:
-          name: "${{ steps.sign-prov.outputs.attestation-name }}"
-          path: "${{ steps.sign-prov.outputs.attestation-name }}"
+          name: "${{ inputs.attestation-name }}"
+          path: "${{ inputs.attestation-name }}"
           if-no-files-found: error
           retention-days: 5
 
@@ -135,7 +139,7 @@ jobs:
       - name: Download the provenance
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1d646d70aeba1516af69fb0ef48206580122449b
         with:
-          name: "${{ needs.generator.outputs.attestation-name }}"
+          name: "${{ inputs.attestation-name }}"
           sha256: "${{ needs.generator.outputs.attestation-sha256 }}"
 
       - name: Release
@@ -143,4 +147,4 @@ jobs:
         id: release
         with:
           files: |
-            ${{ needs.generator.outputs.attestation-name }}
+            ${{ inputs.attestation-name }}

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -37,7 +37,7 @@ on:
       attestation-name:
         description: >
           The artifact name of the signed provenance. 
-          The file must have the an intoto.json extension.
+          The file must have the intoto.json extension.
 
           Default: attestation.intoto.jsonl
         required: false

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -35,7 +35,11 @@ on:
         type: boolean
         default: false
       attestation-name:
-        description: "The artifact name of the signed provenance. (Default: attestation.intoto.jsonl)"
+        description: >
+          The artifact name of the signed provenance. 
+          The file must have the an intoto.json extension.
+
+          Default: attestation.intoto.jsonl
         required: false
         type: string
         default: "attestation.intoto.jsonl"
@@ -49,7 +53,7 @@ on:
         description: "The name of the release where provenance was uploaded."
         value: ${{ jobs.create-release.outputs.release-id }}
       attestation-name:
-        description: "The artifact name of the signed provenance."
+        description: "The artifact name of the signed provenance. (A file with the intoto.json extension)."
         value: "${{ inputs.attestation-name }}"
 
 jobs:

--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -220,6 +220,7 @@ run in the context of a Github Actions workflow.`,
 			p, err := g.Generate(ctx)
 			check(err)
 
+			// Note: we verify the path within getFile().
 			if attPath != "" {
 				var attBytes []byte
 				if utils.IsPresubmitTests() {

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -41,7 +41,7 @@ func Test_pathIsUnderCurrentDirectory(t *testing.T) {
 		},
 		{
 			name:     "some valid path",
-			path:     "../pkg/some/valid/path",
+			path:     "../generic/some/valid/path",
 			expected: nil,
 		},
 		{
@@ -63,10 +63,10 @@ func Test_pathIsUnderCurrentDirectory(t *testing.T) {
 			err := pathIsUnderCurrentDirectory(tt.path)
 			if (err == nil && tt.expected != nil) ||
 				(err != nil && tt.expected == nil) {
-				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Fatalf("unexpected error1: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 
-			if !errors.As(err, &tt.expected) {
+			if err != nil && !errors.As(err, &tt.expected) {
 				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -10,6 +10,63 @@ import (
 	"github.com/slsa-framework/slsa-github-generator/internal/errors"
 )
 
+func Test_pathIsUnderCurrentDirectory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected error
+	}{
+		{
+			name:     "valid same path",
+			path:     "./",
+			expected: nil,
+		},
+		{
+			name:     "valid path no slash",
+			path:     "./some/valid/path",
+			expected: nil,
+		},
+		{
+			name:     "valid path with slash",
+			path:     "./some/valid/path/",
+			expected: nil,
+		},
+		{
+			name:     "valid path with no dot",
+			path:     "some/valid/path/",
+			expected: nil,
+		},
+		{
+			name:     "some valid path",
+			path:     "../pkg/some/valid/path",
+			expected: nil,
+		},
+		{
+			name:     "parent invalid path",
+			path:     "../invalid/path",
+			expected: ErrorInvalidDirectory,
+		},
+		{
+			name:     "some invalid fullpath",
+			path:     "/some/invalid/fullpath",
+			expected: ErrorInvalidDirectory,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := pathIsUnderCurrentDirectory(tt.path)
+			if !errCmp(err, tt.expected) {
+				t.Errorf(cmp.Diff(err, tt.expected))
+			}
+		})
+	}
+}
+
 // TestParseSubjects tests the parseSubjects function.
 func TestParseSubjects(t *testing.T) {
 	testCases := []struct {

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/slsa-framework/slsa-github-generator/internal/errors"
 )
 
+func errCmp(e1, e2 error) bool {
+	return errors.Is(e1, e2) || errors.Is(e2, e1)
+}
+
 func Test_pathIsUnderCurrentDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -63,7 +63,59 @@ func Test_pathIsUnderCurrentDirectory(t *testing.T) {
 			err := pathIsUnderCurrentDirectory(tt.path)
 			if (err == nil && tt.expected != nil) ||
 				(err != nil && tt.expected == nil) {
-				t.Fatalf("unexpected error1: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+			}
+
+			if err != nil && !errors.As(err, &tt.expected) {
+				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+			}
+		})
+	}
+}
+
+func Test_verifyAttestationPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected error
+	}{
+		{
+			name:     "valid file",
+			path:     "./path/to/valid.intoto.jsonl",
+			expected: nil,
+		},
+		{
+			name:     "invalid path",
+			path:     "../some/invalid/valid.intoto.jsonl",
+			expected: &errInvalidPath{},
+		},
+		{
+			name:     "invalid extension",
+			path:     "some/file.ntoto.jsonl",
+			expected: &errInvalidPath{},
+		},
+		{
+			name:     "invalid not exntension",
+			path:     "some/file.intoto.jsonl.",
+			expected: &errInvalidPath{},
+		},
+		{
+			name:     "invalid folder exntension",
+			path:     "file.intoto.jsonl/file",
+			expected: &errInvalidPath{},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyAttestationPath(tt.path)
+			if (err == nil && tt.expected != nil) ||
+				(err != nil && tt.expected == nil) {
+				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 
 			if err != nil && !errors.As(err, &tt.expected) {


### PR DESCRIPTION
See https://github.com/slsa-framework/slsa-github-generator/issues/544

This PR adds an input to the generic re-usable workflow for the attestation filename.