### PR TITLE
fix: upload-asset option in generic generator

### DIFF
--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -144,6 +144,7 @@ jobs:
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1d646d70aeba1516af69fb0ef48206580122449b
         with:
           name: "${{ inputs.attestation-name }}"
+          path: "${{ inputs.attestation-name }}"
           sha256: "${{ needs.generator.outputs.attestation-sha256 }}"
 
       - name: Release


### PR DESCRIPTION
closes https://github.com/slsa-framework/slsa-github-generator/issues/580