### PR TITLE
Haskell provenance

### DIFF
--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -654,7 +654,7 @@ If you use [Haskell](https://www.haskell.org/) (either via
 [`cabal`](https://www.haskell.org/cabal/) or
 [`stack`](https://docs.haskellstack.org/en/stable/README/)) to generate your
 artifacts, you can easily generate SLSA3 provenance by updating your existing
-workflow with the 5 steps indicated in the workflow below.
+workflow with the 3 steps indicated in the workflow below.
 
 ```yaml
 jobs:
@@ -673,13 +673,6 @@ jobs:
     steps:
       [...]
       - name: Build using Haskell
-        # =================================================
-        #
-        # Step 2: Add an `id: build` field
-        #         to your build step
-        #
-        # =================================================
-        id: build
         run: |
           # Your normal build workflow targets here.
           cabal build   # or stack build
@@ -692,7 +685,7 @@ jobs:
 
       # ========================================================
       #
-      # Step 3: Add a step to generate the provenance subjects
+      # Step 2: Add a step to generate the provenance subjects
       #         as shown below. Update the sha256 sum arguments
       #         to include all binaries that you generate
       #         provenance for.
@@ -707,7 +700,7 @@ jobs:
 
   # =========================================================
   #
-  # Step 4: Call the generic workflow to generate provenance
+  # Step 3: Call the generic workflow to generate provenance
   #         by declaring the job below.
   #
   # =========================================================

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -463,7 +463,7 @@ jobs:
         run: |
           # Your normal build workflow targets here
           mvn clean package
-          
+
           # ======================================================
           #
           # Step 3: Save the location of the maven output files
@@ -485,7 +485,7 @@ jobs:
         id: hash
         run: |
           echo "::set-output name=hashes::$(sha256sum ${{ steps.build.outputs.artifact_pattern }} | base64 -w0)"
-      
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
         with:
@@ -554,7 +554,7 @@ jobs:
         id: hash
         run: |
           echo "::set-output name=hashes::$(sha256sum ./build/libs/* | base64 -w0)"
-      
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
         with:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -654,7 +654,7 @@ If you use [Haskell](https://www.haskell.org/) (either via
 [`cabal`](https://www.haskell.org/cabal/) or
 [`stack`](https://docs.haskellstack.org/en/stable/README/)) to generate your
 artifacts, you can easily generate SLSA3 provenance by updating your existing
-workflow with the 3 steps indicated in the workflow below.
+workflow with the steps indicated in the workflow below.
 
 ```yaml
 jobs:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -352,7 +352,7 @@ jobs:
 ### Provenance for Bazel
 
 If you use [Bazel](https://bazel.build/) to generate your artifacts, you can
-easily generate SLSA3 provenance by updating your existing workflow with the 4
+easily generate SLSA3 provenance by updating your existing workflow with the 5
 steps indicated in the workflow below:
 
 ```yaml
@@ -542,7 +542,7 @@ jobs:
 
       # ========================================================
       #
-      # Step 4: Add a step to generate the provenance subjects
+      # Step 3: Add a step to generate the provenance subjects
       #         as shown below. Update the sha256 sum arguments
       #         to include all binaries that you generate
       #         provenance for.
@@ -564,7 +564,7 @@ jobs:
 
   # =========================================================
   #
-  # Step 5: Call the generic workflow to generate provenance
+  # Step 4: Call the generic workflow to generate provenance
   #         by declaring the job below.
   #
   # =========================================================
@@ -617,7 +617,7 @@ jobs:
 
       # ========================================================
       #
-      # Step 4: Add a step to generate the provenance subjects
+      # Step 3: Add a step to generate the provenance subjects
       #         as shown below. Update the sha256 sum arguments
       #         to include all binaries that you generate
       #         provenance for.
@@ -632,7 +632,7 @@ jobs:
 
   # =========================================================
   #
-  # Step 5: Call the generic workflow to generate provenance
+  # Step 4: Call the generic workflow to generate provenance
   #         by declaring the job below.
   #
   # =========================================================


### PR DESCRIPTION
Allows using either Stack or Cabal build tools

Tested via example repo ([Cabal](https://github.com/mihaimaruseac/slsa-lvl3-generic-provenance-in-haskell-example/blob/v0.0.1.1/.github/workflows/ci.yaml), [Stack](https://github.com/mihaimaruseac/slsa-lvl3-generic-provenance-in-haskell-example/blob/v0.0.1.0/.github/workflows/ci.yaml)).

Also did some cleanup (removed trailing whitespace, fixed off-by-one errors)