### PR TITLE
Fix missing digest input and update attestation

### DIFF
--- a/.github/actions/compute-sha256/action.yml
+++ b/.github/actions/compute-sha256/action.yml
@@ -15,17 +15,15 @@ runs:
     - name: Compute the sha256
       id: compute
       shell: bash
-      env:
-        UNTRUSTED_PATH: "${{ inputs.path }}"
       run: |
         set -euo pipefail
 
-        echo "Computing SHA256 for $UNTRUSTED_PATH"
-        if ! [[ -f "$UNTRUSTED_PATH" ]]; then
-            echo "File $UNTRUSTED_PATH not present"
+        echo "Computing SHA256 for $BUILDER_RELEASE_BINARY"
+        if ! [[ -f "$BUILDER_RELEASE_BINARY" ]]; then
+            echo "File $BUILDER_RELEASE_BINARY not present"
             exit 5
         fi
-        digest=$(sha256sum "$UNTRUSTED_PATH" | awk '{print $1}')
+        digest=$(sha256sum "$BUILDER_RELEASE_BINARY" | awk '{print $1}')
         echo "computed sha: $digest"
         
         echo "::set-output name=sha256::$digest"

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -43,17 +43,6 @@ runs:
     - name: Generate builder
       shell: bash
       env:
-        # Builder.
-        BUILDER_REPOSITORY: slsa-framework/slsa-github-generator  # The repository to download the pre-built builder binary from.
-        BUILDER_RELEASE_BINARY: "${{ inputs.binary }}"            # The name of the pre-built binary in the release assets. This is also used as the final binary name when compiling the builder from source.
-        # Verifier
-        # NOTE: These VERIFIER_* variables are used in the builder-fetch.sh script for verification of builder
-        # release binaries when the compile-builder input is false.
-        VERIFIER_REPOSITORY: slsa-framework/slsa-verifier         # The repository to download the pre-built verifier binary from.
-        VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64        # The name of the verifier binary in the release assets.
-        VERIFIER_RELEASE_BINARY_SHA256: f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21  # The expected hash of the verifier binary.
-        VERIFIER_RELEASE: v1.1.1                                   # The version of the verifier to download.
-
         COMPILE_BUILDER: "${{ inputs.compile-builder }}"
         BUILDER_REF: "${{ inputs.ref }}"
         BUILDER_DIR: "${{ inputs.directory }}"
@@ -62,7 +51,5 @@ runs:
       run: ./.github/actions/generate-builder/generate-builder.sh
 
     - name: Compute sha256 of builder
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1d646d70aeba1516af69fb0ef48206580122449b
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@9c56e223d2486617188b6a11ed385ac1a94d77c0
       id: compute
-      with:
-        path: "${{ inputs.binary }}"

--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Compute the hash
       id: compute
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1d646d70aeba1516af69fb0ef48206580122449b
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@9c56e223d2486617188b6a11ed385ac1a94d77c0
       with:
         path: "${{ inputs.path }}"
 

--- a/.github/actions/secure-upload-artifact/action.yml
+++ b/.github/actions/secure-upload-artifact/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Compute binary hash
       id: compute-digest
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@1d646d70aeba1516af69fb0ef48206580122449b
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@9c56e223d2486617188b6a11ed385ac1a94d77c0
       with:
         path: "${{ inputs.path }}"
 

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -136,9 +136,9 @@ jobs:
 
           # Generate a predicate only.
           predicate_name="predicate.json"
-          ./"$BUILDER_BINARY" attest --signature="" --predicate="$predicate_name"
-
+          echo $(echo $(echo $UNTRUSTED_DIGEST | cut -d: -f2) $UNTRUSTED_IMAGE) | base64
+          ./"$BUILDER_RELEASE_BINARY" attest --subjects $(echo $(echo $(echo $UNTRUSTED_DIGEST | cut -d: -f2) $UNTRUSTED_IMAGE) | base64 -w0) --predicate="$predicate_name"
           COSIGN_EXPERIMENTAL=1 cosign attest --predicate="$predicate_name" \
             --type slsaprovenance \
             --force \
-            "${UNTRUSTED_IMAGE}@${UNTRUSTED_DIGEST}"
+            "${UNTRUSTED_IMAGE}"

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -66,7 +66,7 @@ provenance:
     registry-username: ${{ github.actor }}
     digest: ${{ needs.build.outputs.digest }}
     # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
-    compile-generator: true
+    compile-generator: true # currently has to be set true to work
   secrets:
     registry-password: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -139,7 +139,7 @@ jobs:
       registry-username: ${{ github.actor }}
       digest: ${{ needs.build.outputs.digest }}
       # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
-      compile-generator: true
+      compile-generator: true # currently has to be set true to work
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -64,6 +64,7 @@ provenance:
   with:
     image: ${{ needs.build.outputs.tag }}
     registry-username: ${{ github.actor }}
+    digest: ${{ needs.build.outputs.digest }}
     # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
     compile-generator: true
   secrets:
@@ -85,6 +86,7 @@ jobs:
       packages: write
     outputs:
       image: ${{ steps.image.outputs.image }}
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -135,6 +137,7 @@ jobs:
     with:
       image: ${{ needs.build.outputs.image }}
       registry-username: ${{ github.actor }}
+      digest: ${{ needs.build.outputs.digest }}
       # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
       compile-generator: true
     secrets:


### PR DESCRIPTION
This Pull Request:
- adds the digest input
- Fix: attestation generation (adds the missing subjects)
- remove already set env variables
co-authored-by @jobroe10

We made these changes while using the container workflow and realising it was not fully working