### PR TITLE
Remove legacy env vars

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -16,18 +16,8 @@ name: SLSA container image provenance
 
 env:
   # Generator
-  BUILDER_BINARY: generic-generator
-  BUILDER_RELEASE_BINARY: slsa-generator-generic-linux-amd64
-  BUILDER_REPOSITORY: slsa-framework/slsa-github-generator
-  # Verifier
-  # NOTE: These VERIFIER_* variables are used for verification of generator
-  # release binaries when the compile-generator input is false.
-  VERIFIER_REPOSITORY: slsa-framework/slsa-verifier
-  VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64
-  VERIFIER_RELEASE_BINARY_SHA256: f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21
-  VERIFIER_RELEASE: v1.1.1
-  # Builder location
-  BUILDER_DIR: internal/builders
+  BUILDER_BINARY: slsa-generator-generic-linux-amd64 # Name of the binary in the release assets.
+  BUILDER_DIR: internal/builders/generic # Source directory if we compile the builder.
 
 on:
   workflow_call:


### PR DESCRIPTION
Fixes #613

This PR removes legacy env vars from the container workflow. These environment variables were previously used by the scripts that are now part of the [`generate-builder`](https://github.com/slsa-framework/slsa-github-generator/tree/main/.github/actions/generate-builder) action when the script was invoked directly by the workflow itself.