### PR TITLE
Use a temp dir for cwd in tests

### DIFF
--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func Test_PathIsUnderCurrentDirectory(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		path     string
@@ -136,9 +138,26 @@ func Test_VerifyAttestationPath(t *testing.T) {
 	}
 }
 
-func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
-	t.Parallel()
+func tempWD() (func(), error) {
+	// Set up a temporary working directory for the test.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	tempwd, err := os.MkdirTemp("", "slsa-github-generator-tests")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chdir(tempwd); err != nil {
+		return nil, err
+	}
+	return func() {
+		os.RemoveAll(tempwd)
+		os.Chdir(cwd)
+	}, nil
+}
 
+func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 	tests := []struct {
 		name         string
 		path         string
@@ -165,28 +184,15 @@ func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up a temporary working directory for the test.
-			cwd, err := os.Getwd()
+			cleanup, err := tempWD()
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempwd, err := os.MkdirTemp("", "slsa-github-generator-tests")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := os.Chdir(tempwd); err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				os.RemoveAll(tempwd)
-				os.Chdir(cwd)
-			}()
+			defer cleanup()
 
 			if tt.existingPath {
-				if _, err := os.Stat(tt.path); err != nil {
-					if _, err := CreateNewFileUnderCurrentDirectory(tt.path, os.O_WRONLY); err != nil {
-						t.Fatalf("unexpected error: %v", err)
-					}
+				if _, err := CreateNewFileUnderCurrentDirectory(tt.path, os.O_WRONLY); err != nil {
+					t.Fatalf("unexpected error: %v", err)
 				}
 			}
 

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func Test_PathIsUnderCurrentDirectory(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		path     string
@@ -167,7 +165,22 @@ func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// Set up a temporary working directory for the test.
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			tempwd, err := os.MkdirTemp("", "slsa-github-generator-tests")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chdir(tempwd); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				os.RemoveAll(tempwd)
+				os.Chdir(cwd)
+			}()
 
 			if tt.existingPath {
 				if _, err := os.Stat(tt.path); err != nil {
@@ -177,7 +190,7 @@ func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 				}
 			}
 
-			_, err := CreateNewFileUnderCurrentDirectory(tt.path, os.O_WRONLY)
+			_, err = CreateNewFileUnderCurrentDirectory(tt.path, os.O_WRONLY)
 			if (err == nil && tt.expected != nil) ||
 				(err != nil && tt.expected == nil) {
 				t.Fatalf("unexpected error: %v", cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))


### PR DESCRIPTION
Running unit tests created a file at `internal/utils/existing_file` which was left over after tests completed. This PR updates the test to use temporary directory as the current working directory for the tests.