### PR TITLE
chore: update verifier to v1.3.0

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -51,8 +51,8 @@ runs:
         # release binaries when the compile-builder input is false.
         VERIFIER_REPOSITORY: slsa-framework/slsa-verifier # The repository to download the pre-built verifier binary from.
         VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64 # The name of the verifier binary in the release assets.
-        VERIFIER_RELEASE_BINARY_SHA256: f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21 # The expected hash of the verifier binary.
-        VERIFIER_RELEASE: v1.1.1 # The version of the verifier to download.
+        VERIFIER_RELEASE_BINARY_SHA256: 1326430d044e8a9522c51e5f721e237b5f75acb6b4e518d129f669403cf7a79a # The expected hash of the verifier binary.
+        VERIFIER_RELEASE: v1.3.0 # The version of the verifier to download.
 
         COMPILE_BUILDER: "${{ inputs.compile-builder }}"
         BUILDER_REF: "${{ inputs.ref }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ Set up env variables:
 $ export GH_TOKEN=<PAT-token>
 $ export GITHUB_USERNAME="laurentsimon"
 # This is the existing slsa-verifier version used by the builder. (https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/actions/generate-builder/action.yml#L55)
-$ export VERIFIER_TAG="v1.1.1"
+$ export VERIFIER_TAG="v1.3.0"
 $ export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
 # Release tag of the builder we want to release
 $ export BUILDER_TAG="v1.2.0"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This sets the expected sha256 of the v1.3.0 slsa-verifier released binary.

Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0
Clone the slsa-verifier repo, compile and verify the provenance:
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.3.0)
$ go run ./cli/slsa-verifier -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.3.0
Get the hash.
Either:
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
or

sha256sum slsa-verifier-linux-amd64
The output hash should be the hash I'm updating to in this PR. If they match, LGTM. If they don't, someone tampered with the released binary and don't LGTM