### PR TITLE
contents: write is required for the generic builder

### DIFF
--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -131,7 +131,7 @@ jobs:
     permissions:
       actions: read
       id-token: write
-      contents: read
+      contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"


### PR DESCRIPTION
Signed-off-by: Seth Michael Larson <sethmichaellarson@gmail.com>