### PR TITLE
Remove PWD from provenance env

### DIFF
--- a/.github/workflows/scripts/pre-submit.e2e.go.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.go.default.sh
@@ -42,7 +42,7 @@ e2e_verify_predicate_buildConfig_step_env "0" "$ATTESTATION" "[]"
 e2e_verify_predicate_buildConfig_step_workingDir "0" "$ATTESTATION" "$PWD/internal/builders/go/e2e-presubmits"
 
 # Second step is the actual compilation.
-e2e_verify_predicate_buildConfig_step_env "1" "$ATTESTATION" "[\"GOOS=linux\",\"GOARCH=amd64\",\"GO111MODULE=on\",\"CGO_ENABLED=0\", \"PWD=$PWD/internal/builders/go/e2e-presubmits\"]"
+e2e_verify_predicate_buildConfig_step_env "1" "$ATTESTATION" "[\"GOOS=linux\",\"GOARCH=amd64\",\"GO111MODULE=on\",\"CGO_ENABLED=0\"]"
 e2e_verify_predicate_buildConfig_step_workingDir "1" "$ATTESTATION" "$PWD/internal/builders/go/e2e-presubmits"
 
 if [[ -n "$LDFLAGS" ]]; then

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -25,11 +24,6 @@ func errCmp(e1, e2 error) bool {
 
 func Test_runBuild(t *testing.T) {
 	t.Parallel()
-
-	pwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
 	tests := []struct {
 		subject    string
@@ -58,7 +52,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -76,7 +69,6 @@ func Test_runBuild(t *testing.T) {
 			envs: []string{
 				"GOOS=linux",
 				"GOARCH=amd64",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -94,7 +86,6 @@ func Test_runBuild(t *testing.T) {
 			envs: []string{
 				"GOOS=linux",
 				"GOARCH=amd64",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -112,7 +103,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -130,7 +120,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -150,7 +139,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -169,7 +157,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -188,7 +175,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -209,7 +195,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + pwd,
 			},
 		},
 		{
@@ -230,7 +215,6 @@ func Test_runBuild(t *testing.T) {
 				"GOARCH=amd64",
 				"GO111MODULE=on",
 				"CGO_ENABLED=0",
-				"PWD=" + filepath.Join(pwd, "./valid/path/"),
 			},
 			workingDir: "./valid/path/",
 		},

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -108,7 +108,7 @@ func (r *CommandRunner) runStep(ctx context.Context, step *CommandStep, dry bool
 	env = append(env, step.Env...)
 
 	// Set the POSIX PWD env var.
-	posixEnv := make([]string, len(env)+1)
+	posixEnv := make([]string, len(env), len(env)+1)
 	copy(posixEnv, env)
 	pwd, err := filepath.Abs(step.WorkingDir)
 	if err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -32,6 +32,7 @@ func TestCommandRunner_StepEnv(t *testing.T) {
 				Command: []string{"bash", "-c", "echo -n $TEST"},
 				// NOTE: this overrides other env var.
 				Env: []string{"TEST=fuga"},
+				// NOTE: WorkingDir default to CWD
 			},
 		},
 		Stdout: out,
@@ -51,7 +52,7 @@ func TestCommandRunner_StepEnv(t *testing.T) {
 		{
 			Command: []string{"bash", "-c", "echo -n $TEST"},
 			// TODO(https://github.com/slsa-framework/slsa-github-generator/issues/782): de-duplicate env.
-			Env:        []string{"TEST=hoge", "TEST=fuga", "PWD=" + pwd},
+			Env:        []string{"TEST=hoge", "TEST=fuga"},
 			WorkingDir: pwd,
 		},
 	})
@@ -73,6 +74,7 @@ func TestCommandRunner_RunnerEnv(t *testing.T) {
 				Command: []string{"bash", "-c", "echo -n $STEP"},
 				// NOTE: this overrides other env var.
 				Env: []string{"STEP=fuga"},
+				// NOTE: WorkingDir default to CWD
 			},
 		},
 		Stdout: out,
@@ -91,7 +93,7 @@ func TestCommandRunner_RunnerEnv(t *testing.T) {
 	diff := cmp.Diff(steps, []*CommandStep{
 		{
 			Command:    []string{"bash", "-c", "echo -n $STEP"},
-			Env:        []string{"RUNNER=hoge", "STEP=fuga", "PWD=" + pwd},
+			Env:        []string{"RUNNER=hoge", "STEP=fuga"},
 			WorkingDir: pwd,
 		},
 	})
@@ -133,12 +135,12 @@ func TestCommandRunner_RunnerMulti(t *testing.T) {
 	diff := cmp.Diff(steps, []*CommandStep{
 		{
 			Command:    []string{"bash", "-c", "echo $STEP1"},
-			Env:        []string{"STEP1=hoge", "PWD=" + pwd},
+			Env:        []string{"STEP1=hoge"},
 			WorkingDir: pwd,
 		},
 		{
 			Command:    []string{"bash", "-c", "echo $STEP2"},
-			Env:        []string{"STEP2=fuga", "PWD=" + pwd},
+			Env:        []string{"STEP2=fuga"},
 			WorkingDir: pwd,
 		},
 	})


### PR DESCRIPTION
Updates #822 

Remove PWD from the environment variables in provenance build steps as it is redundant with the given working directory. `PWD` is set when executing the command but is not included in the environment variables that are added to the `buildConfig` in the provenance.

Before:
```json
"steps": [
    {
        "command": ["bash", "-c", "echo $STEP2"],
        "env": [
            "STEP2=fuga",
            "PWD=/home/user"
        ],
        "workingDir": "/home/user"
    },
    ...
]
```

After:
```json
"steps": [
    {
        "command": ["bash", "-c", "echo $STEP2"],
        "env": [
            "STEP2=fuga"
        ],
        "workingDir": "/home/user"
    },
    ...
]
```

Signed-off-by: Ian Lewis <ianlewis@google.com>