### PR TITLE
Add call to privacy check to workflows

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
         with:
-          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
 
   rng:

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -55,12 +55,28 @@ on:
         required: false
         type: boolean
         default: false
+      private-repository:
+        description: "If true, private repositories can post to the public transparency log."
+        required: false
+        type: boolean
+        default: false
     outputs:
       go-binary-name:
         description: "The name of the generated binary uploaded to the artifact registry."
         value: ${{ jobs.build-dry.outputs.go-binary-name }}
 
 jobs:
+  privacy-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to read repo info.
+    steps:
+      - name: Check private repos
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        with:
+          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          override: ${{ inputs.private-repository }}
+
   rng:
     outputs:
       value: ${{ steps.rng.outputs.random }}
@@ -91,7 +107,7 @@ jobs:
     outputs:
       go-builder-sha256: ${{ steps.generate.outputs.sha256 }}
     runs-on: ubuntu-latest
-    needs: [detect-env, rng]
+    needs: [privacy-check, detect-env, rng]
     steps:
       - name: Generate builder
         id: generate
@@ -125,7 +141,7 @@ jobs:
       go-env: ${{ steps.build-dry.outputs.go-env }}
       go-working-dir: ${{ steps.build-dry.outputs.go-working-dir }}
     runs-on: ubuntu-latest
-    needs: [builder, rng]
+    needs: [privacy-check, builder, rng]
     steps:
       - name: Checkout the Go repository
         uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@e3220805577deb9d193f64e519abcb3b50851df5
@@ -163,7 +179,7 @@ jobs:
     outputs:
       go-binary-sha256: ${{ steps.upload.outputs.sha256 }}
     runs-on: ubuntu-latest
-    needs: [builder, build-dry, rng]
+    needs: [privacy-check, builder, build-dry, rng]
     steps:
       - name: Checkout the Go repository
         uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@e3220805577deb9d193f64e519abcb3b50851df5

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -249,6 +249,7 @@ jobs:
     permissions:
       id-token: write # Needed to create an OIDC token for keyless signing.
       contents: read
+      actions: read # Needed to read workflow info.
     outputs:
       go-provenance-name: ${{ steps.sign-prov.outputs.signed-provenance-name }}
       go-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
         with:
-          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
 
   # detect-env detects the reusable workflow's repository and ref for use later

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -43,8 +43,24 @@ on:
         required: false
         type: boolean
         default: false
+      private-repository:
+        description: "If true, private repositories can post to the public transparency log."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  privacy-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to read repo info.
+    steps:
+      - name: Check private repos
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        with:
+          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          override: ${{ inputs.private-repository }}
+
   # detect-env detects the reusable workflow's repository and ref for use later
   # in the workflow.
   detect-env:
@@ -70,7 +86,7 @@ jobs:
   # reference.
   generator:
     runs-on: ubuntu-latest
-    needs: [detect-env]
+    needs: [privacy-check, detect-env]
     permissions:
       id-token: write # Needed to get OIDC token for keyless signing.
       actions: read # Needed to read workflow info.

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
         with:
-          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
 
   # detect-env detects the reusable workflow's repository and ref for use later

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: boolean
         default: false
+      private-repository:
+        description: "If true, private repositories can post to the public transparency log."
+        required: false
+        type: boolean
+        default: false
     outputs:
       release-id:
         description: "The name of the release where provenance was uploaded."
@@ -59,6 +64,17 @@ on:
         value: ${{ jobs.generator.outputs.provenance-name }}
 
 jobs:
+  privacy-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to read repo info.
+    steps:
+      - name: Check private repos
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        with:
+          message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
+          override: ${{ inputs.private-repository }}
+
   # detect-env detects the reusable workflow's repository and ref for use later
   # in the workflow.
   detect-env:
@@ -87,7 +103,7 @@ jobs:
       provenance-sha256: ${{ steps.sign-prov.outputs.provenance-sha256 }}
       provenance-name: ${{ steps.sign-prov.outputs.provenance-name }}
     runs-on: ubuntu-latest
-    needs: [detect-env]
+    needs: [privacy-check, detect-env]
     permissions:
       id-token: write # Needed to create an OIDC token for keyless signing.
       contents: read


### PR DESCRIPTION
Fixes #823 

- Adds call to the privacy-check to workflows. Each workflow gets a new `private-repository` input to override this check.
- The Go builder now has `actions: read` permissions in order to support private repos.