### PR TITLE
[docs] Verifying provenance with kyverno

### DIFF
--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -265,7 +265,7 @@ generated as an [in-toto](https://in-toto.io/) statement with a SLSA predicate.
 Verification of provenance attestations can be done via several different tools.
 This section shows examples of several popular tools.
 
-## Kyverno
+### Kyverno
 
 [Kyverno](https://kyverno.io/) is a policy management controller that can be
 used to write Kubernetes-native policies for SLSA provenance. The following


### PR DESCRIPTION
Fixes #389 

Adds an example to the container workflow docs of using a Kyverno policy to verify provenance.

Signed-off-by: Ian Lewis <ianlewis@google.com>