### PR TITLE
Remove contents:read from privacy-check

### DIFF
--- a/.github/actions/privacy-check/action.yml
+++ b/.github/actions/privacy-check/action.yml
@@ -2,7 +2,7 @@ name: "Privacy check"
 description: "Checks if a repository is private and fails if it is."
 inputs:
   token:
-    description: "The GitHub Actions token. It must have contents:read or repo scope."
+    description: "The GitHub Actions token."
     required: false
     default: ${{ github.token }}
   override:

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -68,8 +68,6 @@ on:
 jobs:
   privacy-check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read # Needed to read repo info.
     steps:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -52,8 +52,6 @@ on:
 jobs:
   privacy-check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read # Needed to read repo info.
     steps:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -66,8 +66,6 @@ on:
 jobs:
   privacy-check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read # Needed to read repo info.
     steps:
       - name: Check private repos
         uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22


### PR DESCRIPTION
`contents: read` permissions aren't needed to read a repo object from the GitHub API. Only `metadata` scope is needed and that is given to workflows by default.

Signed-off-by: Ian Lewis <ianlewis@google.com>