### PR TITLE
Add OpenSSF best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/slsa-framework/slsa-github-generator/badge)](https://api.securityscorecards.dev/projects/github.com/slsa-framework/slsa-github-generator)
-
 # Generation of SLSA3+ provenance for native GitHub projects
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/slsa-framework/slsa-github-generator/badge)](https://api.securityscorecards.dev/projects/github.com/slsa-framework/slsa-github-generator)
+[![CII Best
+Practices](https://bestpractices.coreinfrastructure.org/projects/6503/badge)](https://bestpractices.coreinfrastructure.org/projects/6503)
 
 This repository contains tools for generating non-forgeable [SLSA provenance](https://slsa.dev/) on GitHub that meets the [build](https://slsa.dev/spec/v0.1/requirements#build-requirements) and [provenance](https://slsa.dev/spec/v0.1/requirements#provenance-requirements) requirements for [SLSA level 3 and above](https://slsa.dev/spec/v0.1/levels).
 


### PR DESCRIPTION
Updates #886 

Adds an OpenSSF best practices self certification badge.
https://bestpractices.coreinfrastructure.org/en

Signed-off-by: Ian Lewis <ianlewis@google.com>