### PR TITLE
feat: add log when verify-checkout fails

### DIFF
--- a/.github/actions/verify-checkout/action.yaml
+++ b/.github/actions/verify-checkout/action.yaml
@@ -12,5 +12,7 @@ runs:
         git_sha=$(git log -1 --format='%H')
         if [[ "$git_sha" != "$GITHUB_SHA" ]]; then
             echo "mismatch git sha $git_sha != $GITHUB_SHA"
+            echo "logs:"
+            git log
             exit 1
         fi


### PR DESCRIPTION
Will also help debug a renovatebot PR that fails