### PR TITLE
bugfix: pass Github token through to all container sub-workflows

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -39,6 +39,7 @@ runs:
         repository: "${{ inputs.repository }}"
         ref: "${{ inputs.ref }}"
         go-version: "${{ inputs.go-version }}"
+        token: "${{ inputs.token }}"
 
     - name: Generate builder
       shell: bash

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: boolean
         default: false
+      token:
+        description: "GitHub token"
+        required: false
+        type: string
+        default: ${{ github.token }}
 
 jobs:
   privacy-check:
@@ -100,6 +105,7 @@ jobs:
           compile-builder: "${{ inputs.compile-generator }}"
           # NOTE: We are using the generic generator.
           directory: "${{ env.BUILDER_DIR }}"
+          token: "${{ inputs.token }}"
 
       - uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 # tag=v2.6.0
       - name: Login

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -175,6 +175,7 @@ Inputs:
 | `digest`            | yes      | The OCI image digest. The image digest of the form '<algorithm>:<digest>' (e.g. 'sha256:abcdef...') |
 | `registry-username` | yes      | Username to log into the container registry.                                                        |
 | `compile-generator` | false    | Whether to build the generator from source. This increases build time by ~2m.                       |
+| `token`             | false    | The Github token that shall be used by e.g. actions/checkout                                        |
 
 Secrets:
 


### PR DESCRIPTION
I realized that the container provenance workflow does not pass the token through to all the composite workflows and actions.
This causes problems with private repositories.
This PR should fix it.

It's my first contribution to this project, so please let me know if I should create an issue first, or do some more bookkeeping. Thanks for reviewing!