### PR TITLE
Support ref in secure-checkout

### DIFF
--- a/.github/actions/secure-checkout/action.yaml
+++ b/.github/actions/secure-checkout/action.yaml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ${{ github.repository }}
   ref:
-    description: "The ref or SHA to checkout."
+    description: "A fullly formed ref (refs/...) or SHA to checkout."
     required: false
     # NOTE: different from actions/checkout which defaults to GITHUB_REF, GITHUB_SHA, or default branch.
     default: ${{ github.sha }}

--- a/.github/actions/secure-checkout/action.yaml
+++ b/.github/actions/secure-checkout/action.yaml
@@ -39,7 +39,7 @@ runs:
         if [[ "${UNTRUSTED_REF}" =~ ^[a-fA-F0-9]{40}$ ]]; then
           # sha
           sha="${UNTRUSTED_REF}"
-        elif [[ "${UNTRUSTED_REF}" == refs/tags/* ]]; then
+        elif [[ "${UNTRUSTED_REF}" == refs/* ]]; then
           # tag
           sha=$(gh api --header 'Accept: application/vnd.github.v3+json' --method GET "/repos/${UNTRUSTED_REPO}/git/${UNTRUSTED_REF}" | jq -r '.object.sha')
         else

--- a/.github/actions/secure-checkout/action.yaml
+++ b/.github/actions/secure-checkout/action.yaml
@@ -6,12 +6,10 @@ inputs:
     description: "The repository to check out."
     required: false
     default: ${{ github.repository }}
-  sha:
-    description: "The SHA to checkout."
+  ref:
+    description: "The ref or SHA to checkout."
     required: false
-    # NOTE: different from actions/checkout which takes any git ref.
-    # Users must provide a sha1 digest explicitly if not checking out the
-    # commit that triggered the event.
+    # NOTE: different from actions/checkout which defaults to GITHUB_REF, GITHUB_SHA, or default branch.
     default: ${{ github.sha }}
   token:
     description: "Token used to fetch the repository."
@@ -30,19 +28,31 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Verify input sha
+    - name: Get expected sha
+      id: expected
       shell: bash
       env:
-        EXPECTED_SHA: "${{ inputs.sha }}"
-      # Verify that the input sha is a git digest (sha1).
+        UNTRUSTED_REPO: "${{ inputs.repository }}"
+        UNTRUSTED_REF: "${{ inputs.ref }}"
       run: |
-        [[ "${EXPECTED_SHA}" =~ ^[a-fA-F0-9]{40}$ ]]
+        set -euo pipefail
+        if [[ "${UNTRUSTED_REF}" =~ ^[a-fA-F0-9]{40}$ ]]; then
+          # sha
+          sha="${UNTRUSTED_REF}"
+        elif [[ "${UNTRUSTED_REF}" == refs/tags/* ]]; then
+          # tag
+          sha=$(gh api --header 'Accept: application/vnd.github.v3+json' --method GET "/repos/${UNTRUSTED_REPO}/git/${UNTRUSTED_REF}" | jq -r '.object.sha')
+        else
+          echo "Unsupported ref: ${UNTRUSTED_REF}"
+          exit 1
+        fi
+        echo "::set-output name=sha::$sha"
 
     - name: Checkout the repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       with:
         fetch-depth: 1
-        ref: ${{ inputs.sha }}
+        ref: ${{ inputs.ref }}
         persist-credentials: ${{ inputs.persist-credentials }}
         repository: ${{ inputs.repository }}
         token: ${{ inputs.token }}
@@ -51,7 +61,7 @@ runs:
       shell: bash
       env:
         CONTEXT: "${{ toJSON(github) }}"
-        EXPECTED_SHA: "${{ inputs.sha }}"
+        EXPECTED_SHA: "${{ steps.expected.sha }}"
       run: |
         set -euo pipefail
 

--- a/.github/actions/secure-checkout/action.yaml
+++ b/.github/actions/secure-checkout/action.yaml
@@ -61,7 +61,7 @@ runs:
       shell: bash
       env:
         CONTEXT: "${{ toJSON(github) }}"
-        EXPECTED_SHA: "${{ steps.expected.sha }}"
+        EXPECTED_SHA: "${{ steps.expected.outputs.sha }}"
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
Updates #968

This PR changes the `sha` input for `secure-checkout` to `ref` and allows passing git a `ref` or `sha`. The action now performs validation by looking up the `ref` in the API and checking that the sha digest returned by the API and the sha checked out locally match. This may not necessarily satisfy the TLS interception issue brought up on #626 but at least makes it a little harder to fake a checkout.

We need to support `ref` in `secure-checkout` because we need to be able to checkout the builder using a tag reference. This is because we recommend users call our workflows using a release tag.

e.g.
```yaml
uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
```

This results in `detect-env` action returning something like `refs/tags/v1.2.0` as the detected reference.