### PR TITLE
Use ref for secure-checkout

### DIFF
--- a/.github/actions/checkout-go/action.yml
+++ b/.github/actions/checkout-go/action.yml
@@ -23,9 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user SHA
-      # FIXME: update digest when #1005 is merged.
-      # uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
-      uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@cd072cfe086700df36a3e7a7cea2c74ec675bdf4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/checkout-go/action.yml
+++ b/.github/actions/checkout-go/action.yml
@@ -6,9 +6,10 @@ inputs:
     required: false
     # Same default as https://github.com/actions/checkout/blob/main/action.yml#L6.
     default: ${{ github.repository }}
-  sha:
-    description: "The SHA to checkout."
+  ref:
+    description: "The ref or SHA to checkout."
     required: false
+    default: ${{ github.sha }}
   token:
     description: "The token to use."
     required: false
@@ -22,14 +23,15 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user SHA
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
+      # FIXME: update digest when #1005 is merged.
+      # uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
+      uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
       with:
-        # TODO(github.com/slsa-framework/slsa-github-generator/issues/996): Don't quote values to preserve defaults.
-        repository: "${{ inputs.repository }}"
-        sha: "${{ inputs.sha }}"
-        token: "${{ inputs.token }}"
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+        token: ${{ inputs.token }}
 
     - name: Set up Go environment
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # tag=v3.3.0
       with:
-        go-version: "${{ inputs.go-version }}"
+        go-version: ${{ inputs.go-version }}

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -7,7 +7,7 @@ inputs:
     # Same default as https://github.com/actions/checkout/blob/main/action.yml#L6.
     default: ${{ github.repository }}
   ref:
-    description: "The ref or SHA to checkout."
+    description: "A fully formed ref (refs/...) or SHA to checkout."
     required: false
     default: ${{ github.sha }}
   token:

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -6,9 +6,10 @@ inputs:
     required: false
     # Same default as https://github.com/actions/checkout/blob/main/action.yml#L6.
     default: ${{ github.repository }}
-  sha:
-    description: "The SHA to checkout."
+  ref:
+    description: "The ref or SHA to checkout."
     required: false
+    default: ${{ github.sha }}
   token:
     description: "The token to use."
     required: false
@@ -22,14 +23,16 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user ref
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
+      # FIXME: update digest when #1005 is merged.
+      # uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
+      uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
       with:
         # TODO(github.com/slsa-framework/slsa-github-generator/issues/996): Don't quote values to preserve defaults.
-        repository: "${{ inputs.repository }}"
-        sha: "${{ inputs.sha }}"
-        token: "${{ inputs.token }}"
+        repository: ${{ inputs.repository }}
+        sha: ${{ inputs.sha }}
+        token: ${{ inputs.token }}
 
     - name: Set up Node environment
       uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3.4.1
       with:
-        node-version: "${{ inputs.node-version }}"
+        node-version: ${{ inputs.node-version }}

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -23,9 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user ref
-      # FIXME: update digest when #1005 is merged.
-      # uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
-      uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@cd072cfe086700df36a3e7a7cea2c74ec675bdf4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
       with:
         repository: ${{ inputs.repository }}
-        sha: ${{ inputs.sha }}
+        ref: ${{ inputs.ref }}
         token: ${{ inputs.token }}
 
     - name: Set up Node environment

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -27,7 +27,6 @@ runs:
       # uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@f348c29e4be53b8413640f1f2eabd3fbde249a15
       uses: ianlewis/slsa-github-generator/.github/actions/secure-checkout@secure-checkout-ref
       with:
-        # TODO(github.com/slsa-framework/slsa-github-generator/issues/996): Don't quote values to preserve defaults.
         repository: ${{ inputs.repository }}
         sha: ${{ inputs.sha }}
         token: ${{ inputs.token }}

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -36,10 +36,9 @@ runs:
     - name: Checkout the Go builder repository
       uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@74c98157d0a85b0a7fee968e0bd247b58923a8b6
       with:
-        # TODO(github.com/slsa-framework/slsa-github-generator/issues/996): Don't quote values to preserve defaults.
-        repository: "${{ inputs.repository }}"
-        sha: "${{ inputs.sha }}"
-        go-version: "${{ inputs.go-version }}"
+        repository: ${{ inputs.repository }}
+        sha: ${{ inputs.sha }}
+        go-version: ${{ inputs.go-version }}
 
     - name: Generate builder
       shell: bash

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -1,8 +1,8 @@
 name: "Generate the builder"
 description: "Build or fetch the builder binary"
 inputs:
-  sha:
-    description: "SHA of the builder."
+  ref:
+    description: "A fully formed ref (refs/...) or SHA to checkout."
     required: true
   repository:
     description: "Repository of the builder."
@@ -37,7 +37,7 @@ runs:
       uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@74c98157d0a85b0a7fee968e0bd247b58923a8b6
       with:
         repository: ${{ inputs.repository }}
-        sha: ${{ inputs.sha }}
+        ref: ${{ inputs.ref }}
         go-version: ${{ inputs.go-version }}
 
     - name: Generate builder


### PR DESCRIPTION
Updates #968
Requires #1005 

Updates `checkout-go` and `checkout-node` to use the newer version of `secure-checkout` that supports the `ref` input.

Signed-off-by: Ian Lewis <ianlewis@google.com>