### PR TITLE
fix: fix ref from detect-env in pull_request

### DIFF
--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -99,7 +99,8 @@ func (a *action) getRepoRef(ctx context.Context) (string, string, error) {
 	if eventName == "pull_request" {
 		// If a pull request get the repo from the pull request.
 		repository = a.getEventValue("pull_request.head.repo.full_name")
-		ref = a.getenv("GITHUB_HEAD_REF")
+		// We use the SHA of the head branch of the pull request.
+		ref = a.getEventValue("pull_request.head.sha")
 	} else {
 		audience := a.getenv("GITHUB_REPOSITORY")
 		if audience == "" {
@@ -126,6 +127,7 @@ func (a *action) getRepoRef(ctx context.Context) (string, string, error) {
 		if len(refParts) < 2 {
 			return "", "", errors.New("missing reference in job workflow ref")
 		}
+		// This is a fully formed ref, in the form refs/*.
 		ref = refParts[1]
 	}
 

--- a/.github/actions/detect-workflow/main_test.go
+++ b/.github/actions/detect-workflow/main_test.go
@@ -149,7 +149,6 @@ func Test_action_getRepoRef(t *testing.T) {
 				env := map[string]string{
 					"GITHUB_REPOSITORY": "githubuser/reponame",
 					"GITHUB_EVENT_NAME": "pull_request",
-					"GITHUB_HEAD_REF":   "refs/heads/mybranch",
 				}
 				return env[k]
 			},
@@ -162,6 +161,7 @@ func Test_action_getRepoRef(t *testing.T) {
 						"repo": map[string]any{
 							"full_name": "otheruser/reponame",
 						},
+						"sha": "123",
 					},
 				},
 			},
@@ -174,7 +174,7 @@ func Test_action_getRepoRef(t *testing.T) {
 		if want, got := "otheruser/reponame", repo; want != got {
 			t.Errorf("unexpected repository, want: %q, got: %q", want, got)
 		}
-		if want, got := "refs/heads/mybranch", ref; want != got {
+		if want, got := "123", ref; want != got {
 			t.Errorf("unexpected ref, want: %q, got: %q", want, got)
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This fixes the ref from detect-env in pull_request of the workflows to be a SHA, rather than a not-fully-formed GITHUB_HEAD_REF