### PR TITLE
fix: use updated ref for secure-checkout

### DIFF
--- a/.github/actions/checkout-go/action.yml
+++ b/.github/actions/checkout-go/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user SHA
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@cd072cfe086700df36a3e7a7cea2c74ec675bdf4
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@ea457948e6a989e9818304dcb4f15fb4ce6765d6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/checkout-node/action.yml
+++ b/.github/actions/checkout-node/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository with user ref
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@cd072cfe086700df36a3e7a7cea2c74ec675bdf4
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-checkout@ea457948e6a989e9818304dcb4f15fb4ce6765d6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This pulls in Ian's bug fix for secure-checkout https://github.com/slsa-framework/slsa-github-generator/commit/ea457948e6a989e9818304dcb4f15fb4ce6765d6 and updates the callers `checkout-go` and `checkout-node`