### PR TITLE
fix: update refs for checkout-go

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the Go builder repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@f5aa6f995bc416d2315efdcd987fda653f163b88
+      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -146,7 +146,7 @@ jobs:
     needs: [privacy-check, builder, rng]
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@f5aa6f995bc416d2315efdcd987fda653f163b88
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -183,7 +183,7 @@ jobs:
     needs: [privacy-check, builder, build-dry, rng]
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@f5aa6f995bc416d2315efdcd987fda653f163b88
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
         with:
           go-version: ${{ inputs.go-version }}
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Uses the updated commit https://github.com/slsa-framework/slsa-github-generator/commit/b447920901e060ac2459d2e87fee02652033593e for `checkout-go`