### PR TITLE
fix: update refs for checkout-go

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the Go builder repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
+      uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@c2e7da4c53f2703d9af77f8d1483078c8fd3477e
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -146,7 +146,7 @@ jobs:
     needs: [privacy-check, builder, rng]
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@c2e7da4c53f2703d9af77f8d1483078c8fd3477e
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -183,7 +183,7 @@ jobs:
     needs: [privacy-check, builder, build-dry, rng]
     steps:
       - name: Checkout the Go repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@fa78a70b888bc0acd41fd48aa731fb8d610d5b1b
+        uses: slsa-framework/slsa-github-generator/.github/actions/checkout-go@c2e7da4c53f2703d9af77f8d1483078c8fd3477e
         with:
           go-version: ${{ inputs.go-version }}
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Updates ref from https://github.com/slsa-framework/slsa-github-generator/commit/c2e7da4c53f2703d9af77f8d1483078c8fd3477e for the `checkout-go` action.

One more after this!