### PR TITLE
Add pre-submit for secure-checkout

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -91,3 +91,20 @@ jobs:
         run: |
           echo "Got output: $OUTPUT"
           [[ "$OUTPUT" != "" ]]
+
+  # Test secure-checkout of the repository that triggered the workflow.
+  secure-checkout-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+      - uses: ./.github/actions/secure-checkout
+
+  # Test secure-checkout of a separate repository.
+  secure-checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+      - uses: ./.github/actions/secure-checkout
+        with:
+          repository: slsa-framework/slsa
+          ref: refs/tags/v0.1

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -104,7 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: ./.github/actions/secure-checkout
+        # Check out to a separate path since secure-checkout will overwrite our workspace.
+        path: secure-checkout/
+      - uses: ./secure-checkout/.github/actions/secure-checkout
         with:
           repository: slsa-framework/slsa
           ref: refs/tags/v0.1

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -99,15 +99,18 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - uses: ./.github/actions/secure-checkout
 
+  # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/1073): Support 'path' input in secure-checkout
+  # NOTE: Commented out because secure-checkout overwrites the local workspace and fails action cleanup.
+  #
   # Test secure-checkout of a separate repository.
-  secure-checkout:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-        # Check out to a separate path since secure-checkout will overwrite our workspace.
-        with:
-          path: secure-checkout/
-      - uses: ./secure-checkout/.github/actions/secure-checkout
-        with:
-          repository: slsa-framework/slsa
-          ref: refs/tags/v0.1
+  # secure-checkout:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+  #       # Check out to a separate path since secure-checkout will overwrite our workspace.
+  #       with:
+  #         path: secure-checkout/
+  #     - uses: ./secure-checkout/.github/actions/secure-checkout
+  #       with:
+  #         repository: slsa-framework/slsa
+  #         ref: refs/tags/v0.1

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -105,7 +105,8 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         # Check out to a separate path since secure-checkout will overwrite our workspace.
-        path: secure-checkout/
+        with:
+          path: secure-checkout/
       - uses: ./secure-checkout/.github/actions/secure-checkout
         with:
           repository: slsa-framework/slsa

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -15,3 +15,4 @@ rules:
     allowed-values: ["true", "false"]
     # Allow Github Actions keys like 'on'
     check-keys: false
+  comments-indentation: false


### PR DESCRIPTION
Adds pre-submits for `secure-checkout` that runs the code included in the PR. 

These pre-submits need to be added as required to the protected branch after merge.

Signed-off-by: Ian Lewis <ianlewis@google.com>