### PR TITLE
Document renovate exception for tags over digest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ reusable workflow. It also needs to be referred as `@vX.Y.Z`, because the build 
 This is contrary to the [GitHub best practice for third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) which recommends referencing by digest, but intentional due to limits in GitHub Actions.
 The desire to be able to verify reusable workflows pinned by hash, and the reasons for the current status, are tracked as [Issue #12](https://github.com/slsa-framework/slsa-verifier/issues/12) in the slsa-verifier project.
 
+For guidance on how to configure renovate see [RENOVATE.md](RENOVATE.md).
+
 ### Builders
 
 Builders build and generate provenance. They let you meet the [build](https://slsa.dev/spec/v0.1/requirements#build-requirements)

--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -1,0 +1,19 @@
+# Renovate Best Practices and SLSA-GitHub-Generator
+
+Renovate helps users to enforce security best practices when continuously upgrading GitHub actions.
+
+Renovate provides a configuration snippet, which is used by most GitHub projects, to [automatically pin dependencies using the digest](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) instead of git tags: `helpers:pinGitHubActionDigests`.
+
+To add an exception to this rule for slsa-github-generator add the following package rule to your `renovate.json` config.
+
+```json
+"packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["slsa-framework/slsa-github-generator"],
+      "pinDigests": false
+    }
+  ]
+```
+
+This will enable you to receive upgrades for the generator and keep the tagged version.


### PR DESCRIPTION
As proposed in https://github.com/slsa-framework/slsa-verifier/issues/12#issuecomment-1280619107 it might be helpful for other users to have a handy renovate snippet to follow the README's guidance on using tags instead of digests.

Signed-off-by: Fabian Kammel <fk@edgeless.systems>