### PR TITLE
fix: checkout uses the wrong repository

### DIFF
--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -142,7 +142,7 @@ jobs:
       go-env: ${{ steps.build-dry.outputs.go-env }}
       go-working-dir: ${{ steps.build-dry.outputs.go-working-dir }}
     runs-on: ubuntu-latest
-    needs: [privacy-check, builder, rng]
+    needs: [privacy-check, builder, rng, detect-env]
     steps:
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
@@ -188,7 +188,7 @@ jobs:
     outputs:
       go-binary-sha256: ${{ steps.upload.outputs.sha256 }}
     runs-on: ubuntu-latest
-    needs: [privacy-check, builder, build-dry, rng]
+    needs: [privacy-check, builder, build-dry, rng, detect-env]
     steps:
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
@@ -262,7 +262,7 @@ jobs:
   ###################################################################
   provenance:
     runs-on: ubuntu-latest
-    needs: [builder, build, build-dry, rng]
+    needs: [builder, build, build-dry, rng, detect-env]
     permissions:
       id-token: write # Needed to create an OIDC token for keyless signing.
       contents: read
@@ -326,7 +326,7 @@ jobs:
     permissions:
       contents: write # Needed to write artifacts to a release.
     runs-on: ubuntu-latest
-    needs: [build-dry, build, provenance]
+    needs: [build-dry, build, provenance, detect-env]
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - name: Checkout builder repository

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check private repos
-        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@main
         with:
           error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@e3220805577deb9d193f64e519abcb3b50851df5
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@main
 
   detect-env:
     outputs:
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@efb47d340c150ce456bf8bd554a131ac53b10ccd # tag=v1.2.0
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@main # tag=v1.2.0
 
   ###################################################################
   #                                                                 #
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Generate builder binary
         id: generate
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -145,7 +145,7 @@ jobs:
     needs: [privacy-check, builder, rng, detect-env]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -191,7 +191,7 @@ jobs:
     needs: [privacy-check, builder, build-dry, rng, detect-env]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -272,7 +272,7 @@ jobs:
       go-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -330,7 +330,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/builder_node_slsa3.yml
+++ b/.github/workflows/builder_node_slsa3.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check private repos
-        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@main
         with:
           error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
@@ -145,7 +145,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@e3220805577deb9d193f64e519abcb3b50851df5
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@main
 
   detect-env:
     outputs:
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@efb47d340c150ce456bf8bd554a131ac53b10ccd # tag=v1.2.0
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@main # tag=v1.2.0
 
   ###################################################################
   #                                                                 #
@@ -172,7 +172,7 @@ jobs:
     steps:
       - name: Generate builder
         id: generate
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -203,7 +203,7 @@ jobs:
     needs: [privacy-check, builder, rng]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -302,7 +302,7 @@ jobs:
       node-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -359,7 +359,7 @@ jobs:
     needs: [build, provenance]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/builder_node_slsa3.yml
+++ b/.github/workflows/builder_node_slsa3.yml
@@ -200,7 +200,7 @@ jobs:
       node-tarball-sha256: ${{ steps.upload.outputs.sha256 }}
       node-tarball-name: ${{ steps.tarball.outputs.filename }}
     runs-on: ubuntu-latest
-    needs: [privacy-check, builder, rng]
+    needs: [privacy-check, builder, rng, detect-env]
     steps:
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
@@ -356,7 +356,7 @@ jobs:
   ###################################################################
   publish:
     runs-on: ubuntu-latest
-    needs: [build, provenance]
+    needs: [build, provenance, detect-env]
     steps:
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main

--- a/.github/workflows/builder_node_slsa3.yml
+++ b/.github/workflows/builder_node_slsa3.yml
@@ -292,7 +292,7 @@ jobs:
   ###################################################################
   provenance:
     runs-on: ubuntu-latest
-    needs: [builder, build, rng]
+    needs: [builder, build, rng, detect-env]
     permissions:
       id-token: write # Needed to create an OIDC token for keyless signing.
       contents: read

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check private repos
-        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@a3c7a56c8749c2c423f01bbcfd063315efc07a22
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@main
         with:
           error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ inputs.private-repository }}
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Detect the generator ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@efb47d340c150ce456bf8bd554a131ac53b10ccd
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@main
 
   # generator builds the generator binary and runs it to generate SLSA
   # provenance.
@@ -91,7 +91,7 @@ jobs:
       packages: write # Needed to login and upload attestations to ghcr.io.
     steps:
       - name: Generate builder
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@923a5a249d2ea820614a80486c9ef0857ced5321
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -163,7 +163,7 @@ jobs:
     outputs:
       release-id: ${{ steps.release.outputs.id }}
     runs-on: ubuntu-latest
-    needs: [generator]
+    needs: [generator, detect-env]
     permissions:
       contents: write # Needed to write artifacts to a release.
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       release-tag:
         description: 'Release tag to test'
-        required: true 
+        required: true
         type: string
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Builders realeaser
 on:
   # For manual tests.
   workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Release tag to test'
+        required: true 
+        type: string
   push:
     tags:
       - "*" # triggers only if push new tag version, like `0.8.4` or else
@@ -10,8 +15,27 @@ on:
 permissions: read-all
 
 jobs:
+  # Pre-release reference verification.
+  pre-release-refs:
+    name: pre release refs verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+      - name: manual release ref
+        env:
+          RELEASE_TAG: "${{ inputs.release-tag }}"
+        if: github.ref_type != 'tag'
+        run: ./.github/workflows/scripts/pre-release/references.sh
+
+      - name: new tag release ref
+        env:
+          RELEASE_TAG: "${{ github.ref_name }}"
+        if: github.ref_type == 'tag'
+        run: ./.github/workflows/scripts/pre-release/references.sh
+
   # Generic generator.
   generic-generator:
+    needs: [pre-release-refs]
     permissions:
       id-token: write # For signing.
       contents: write # For asset uploads.
@@ -24,8 +48,7 @@ jobs:
 
   # Go builder.
   go-builder:
-    # Force the builds to rin sequentially, to avoid
-    # the builder binaries being overwritten by each run.
+    needs: [pre-release-refs]
     permissions:
       id-token: write # For signing.
       contents: write # For asset uploads.

--- a/.github/workflows/scripts/pre-release/references.sh
+++ b/.github/workflows/scripts/pre-release/references.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Verify that Action calls that are pinned (not locally called)
+# use the same referemnce as the relealse tag.
+# See reasoning in ./github/actions/README.md
+
+set -euo pipefail
+
+results=$(
+    find .github/workflows/ -name '*.yaml' -o -name '*.yml' \
+    | xargs grep -P "slsa-framework/slsa-github-generator/.github/actions/.*@(?!$RELEASE_TAG)" \
+    || true
+)
+if [[ "$results" != "" ]]; then
+    echo "Some Actions are not referenced via the correct release tag \"$RELEASE_TAG\""
+    echo "$results"
+    exit 1
+fi
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,9 +33,11 @@ $ export GH=/path/to/gh
 
 ## Pre-release tests
 
-Needless to say, only think about a release when all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
+Verify the references to the internal Actions by manually running the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds.
 
-1. Verify the references to the internal Actions by manually running the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds.
+Code freeze the repository for 1-2 days.
+
+Verify all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
 
 There is one integration test we cannot easily test "live", so we need to simulate it by changing the code: malicious verifier binary in assets. We want to be sure the builder fails if the verifier's binary is tampered with. For this:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,8 @@ $ export GH=/path/to/gh
 
 Needless to say, only think about a release when all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
 
+1. Verify the references to the internal Actions by manually running the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds.
+
 There is one integration test we cannot easily test "live", so we need to simulate it by changing the code: malicious verifier binary in assets. We want to be sure the builder fails if the verifier's binary is tampered with. For this:
 
 1. Create a new release for your fork of the slsa-verifier repository with a malicious binary.


### PR DESCRIPTION
This will fix the current error that affects all e2e tests.
The PR also uses `@main` for all the actions we use. We will set these to the tag release before release. I have added pre-release workflows to verify the release tag and the reference of the Actions is the same' and amended the RELEASE.md accordingly.