### PR TITLE
Update README.md

### DIFF
--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -134,7 +134,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release


### PR DESCRIPTION
Update the generic provenance generator's code example to use generator_generic_slsa3 v1.2.1. The code example uses v1.2.0, but the text describes the inputs 'provenance-name' and 'private-repository' which exist only in v1.2.1. 

Instead, we could update the text, and add "Available in version 1.2.1" to the definitions of  'provenance-name' and 'private-repository'.

Signed-off-by: Wietse Z Venema <72045954+wietse-gmail@users.noreply.github.com>