### PR TITLE
verifier: update verifier version to v1.3.2

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -67,8 +67,8 @@ runs:
         # release binaries when the compile-builder input is false.
         VERIFIER_REPOSITORY: slsa-framework/slsa-verifier # The repository to download the pre-built verifier binary from.
         VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64 # The name of the verifier binary in the release assets.
-        VERIFIER_RELEASE_BINARY_SHA256: 065714d01ba36c81fb11aa7031597a77b08491eb341bac8efc3e452f5d5ed4bd # The expected hash of the verifier binary.
-        VERIFIER_RELEASE: v1.3.1 # The version of the verifier to download.
+        VERIFIER_RELEASE_BINARY_SHA256: b1d6c9bbce6274e253f0be33158cacd7fb894c5ebd643f14a911bfe55574f4c0 # The expected hash of the verifier binary.
+        VERIFIER_RELEASE: v1.3.2 # The version of the verifier to download.
 
         COMPILE_BUILDER: "${{ inputs.compile-builder }}"
         BUILDER_REF: "${{ inputs.ref }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ Set up env variables:
 $ export GH_TOKEN=<PAT-token>
 $ export GITHUB_USERNAME="laurentsimon"
 # This is the existing slsa-verifier version used by the builder. (https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/actions/generate-builder/action.yml#L55)
-$ export VERIFIER_TAG="v1.3.1"
+$ export VERIFIER_TAG="v1.3.2"
 $ export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
 # Release tag of the builder we want to release
 $ export BUILDER_TAG="v1.2.0"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Pending https://github.com/slsa-framework/slsa-verifier/pull/347/

To verify, see that PR:

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.2 (or the other)
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$  go run ./cli/slsa-verifier verify-artifact ~/Downloads/slsa-verifier-linux-amd64 --provenance-path ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl --source-uri github.com/slsa-framework/slsa-verifier --source-tag v1.3.2 --source-branch release/v1.3
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```