### PR TITLE
Group updates for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "schedule": ["every weekend"],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "groupName": "github-actions",
-      "commitMessageTopic": "github-actions"
+      "groupName": "github-actions"
     },
     {
-      "extends": "group:nodeJs",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "nodeJs",
-      "commitMessageTopic": "NodeJs"
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "go"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "npm dev"
     }
   ]
 }


### PR DESCRIPTION
This should hopefully group up some updates so that they are easier to merge.

The intention of the update is as follows:
- Go updates that are minor and patch version updates should be grouped into a single PR. Major updates would not be grouped.
- npm dependencies that are minor and patch version update should be grouped into a single PR. Major updates would not be grouped.
- npm devDependencies should be grouped into a single PR.
- GitHub actions dependencies should be grouped.

Signed-off-by: Ian Lewis <ianlewis@google.com>