### PR TITLE
Update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ This is a document to describe the release process for the Go builder. Since all
 ---
 
 - [Pre-release](#pre-release-tests)
-- [Verify version references & code freeze](#verify-version-references-code-freeze)
+- [Verify version references & code freeze](#verify-version-references--code-freeze)
 - [Tagging](#tagging)
 - [Post-release tests](#post-release-tests)
 - [Update Verifier](#update-verifier)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,7 +48,7 @@ Click `Publish release`.
 Update version references with the following command:
 
 ```shell
-find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@main*/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@$BUILDER_TAG/"
+find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@\(main\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@$BUILDER_TAG/"
 ```
 
 Send a PR with this update and add `#label:release` in the PR description.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,8 +5,8 @@ This is a document to describe the release process for the Go builder. Since all
 ---
 
 - [Pre-release](#pre-release-tests)
-- [Verify version references & code freeze](#verify-version-references--code-freeze)
 - [Tagging](#tagging)
+- [Verify version references & code freeze](#verify-version-references--code-freeze)
 - [Post-release tests](#post-release-tests)
 - [Update Verifier](#update-verifier)
 - [Finalize release](#finalize-release)


### PR DESCRIPTION
Updates the release instructions to create a pre-release tag at the beginning so we can update tag references before pre-release testing.

Signed-off-by: Ian Lewis <ianlewis@google.com>