### PR TITLE
[generic] fix attestation file creation when subject names are in subdirectories

### DIFF
--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/spf13/cobra"
@@ -59,7 +60,8 @@ run in the context of a Github Actions workflow.`,
 			// validated. This is done by CreateNewFileUnderCurrentDirectory.
 			if attPath == "" {
 				if len(parsedSubjects) == 1 {
-					attPath = fmt.Sprintf("%s.intoto.jsonl", parsedSubjects[0].Name)
+					filename := path.Base(parsedSubjects[0].Name)
+					attPath = fmt.Sprintf("%s.intoto.jsonl", filename)
 				} else {
 					// len(parsedSubjects) > 1
 					attPath = "multiple.intoto.jsonl"

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -180,6 +180,15 @@ func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 			existingPath: true,
 			expected:     &ErrInvalidPath{},
 		},
+		{
+			name: "new file",
+			path: "new_file",
+		},
+		{
+			name:     "new file in sub-directory",
+			path:     "dir/new_file",
+			expected: &ErrInvalidPath{},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Updates https://github.com/slsa-framework/slsa-github-generator/issues/1225

The generic SLSA 3 generator attests to subjects given as input and their digest. However, if the subject is in a sub-directory, then it will fail creating the attestation because the sub-directory doesn't exist.

This retrieves the Base for the subject name, instead of the full path name.
@ianlewis I could also have created the sub-directory, but that made a lot less sense to me.