### PR TITLE
Update RELEASE docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Builders realeaser
+name: Builders releaser
 
 on:
   # For manual tests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -244,7 +244,10 @@ You will need the following trigger types:
 - A tag of the form `vX.Y.Z`.
 - Tags of the form `vX` and `vX.Y`.
 
-To do this, trigger the [Go workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.go.workflow_dispatch.main.all.slsa3.yml) and [Generic workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.generic.workflow_dispatch.main.all.slsa3.yml). These will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on fixed tags.
+To do this, trigger the following workflows, waiting for each to finish before starting the next. These will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on fixed tags.
+
+- [Go workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.go.workflow_dispatch.main.all.slsa3.yml)
+- [Generic workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.generic.workflow_dispatch.main.all.slsa3.yml).
 
 Download the uploaded artifacts of each of these, labelling the workflow dispatch artifacts by `binary-linux-amd64-workflow_dispatch(.intoto.jsonl)` and the tags by `binary-linux-amd64-push-v$TAG(.intoto.jsonl)`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -260,7 +260,7 @@ Untick the `This is a pre-release` option.
 Update the documentation to recommend using the new version:
 
 ```shell
-find . -name "*.md" -exec sed -i "s/v1.0.0/v1.1.1/g" {} +
+find . -name '*.md' | xargs sed -i "s/slsa-framework\/slsa-github-generator\/\.github\/\(.*\)@v[0-9]\+\.[0-9]\+\.[0-9]\+/slsa-framework\/slsa-github-generator\/.github\/\1@${BUILDER_TAG}/"
 ```
 
 ## Send a PR to reference Actions at main
@@ -268,7 +268,7 @@ find . -name "*.md" -exec sed -i "s/v1.0.0/v1.1.1/g" {} +
 Send a PR to reference the internal Actions at `@main`. You can use:
 
 ```shell
-find .github/ -name '*.yaml' -o -name '*.yml' | xargs sed -i 's/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@_YOUR_RELEASE_TAG_*/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@main/'
+find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@${BUILDER_TAG}/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@main/"
 ```
 
 ## Update the starter workflows

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,17 +21,17 @@ This is a document to describe the release process for the Go builder. Since all
 Set up env variables:
 
 ```shell
-$ export GH_TOKEN=<PAT-token>
-$ export GITHUB_USERNAME="laurentsimon"
+export GH_TOKEN=<PAT-token>
+export GITHUB_USERNAME="laurentsimon"
 # This is the existing slsa-verifier version used by the builder. (https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/actions/generate-builder/action.yml#L55)
-$ export VERIFIER_TAG="v1.3.2"
-$ export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
+export VERIFIER_TAG="v1.3.2"
+export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
 # Release tag of the builder we want to release
-$ export BUILDER_TAG="v1.2.0"
+export BUILDER_TAG="v1.2.0"
 # Branch name for our test
-$ export BUILDER_REF="release/bad-verifier-$BUILDER_TAG"
-$ export BUILDER_REPOSITORY="$GITHUB_USERNAME/slsa-github-generator"
-$ export GH=/path/to/gh
+export BUILDER_REF="release/bad-verifier-$BUILDER_TAG"
+export BUILDER_REPOSITORY="$GITHUB_USERNAME/slsa-github-generator"
+export GH=/path/to/gh
 ```
 
 ## Tagging
@@ -65,16 +65,17 @@ There is one integration test we cannot easily test "live", so we need to simula
 
 1. Create a new release for your fork of the slsa-verifier repository with a malicious binary.
 
+   Create a release. Note that this will create a release workflow: cancel it in the GitHub UI.
+
    ```shell
-   # Create a release
+   "$GH" release -R "$VERIFIER_REPOSITORY" create "$VERIFIER_TAG" --title "$VERIFIER_TAG" --notes "pre-release tests for builder $BUILDER_TAG $(date)"
+   ```
 
-   $ "$GH" release -R "$VERIFIER_REPOSITORY" create "$VERIFIER_TAG" --title "$VERIFIER_TAG" --notes "pre-release tests for builder $BUILDER_TAG $(date)"
-   $ # Note: this will create a release workflow: cancel it in the GitHub UI.
+   Simulate uploading a malicious binary.
 
-   # Upload a malicious binary.
-
-   $ echo hello > slsa-verifier-linux-amd64
-   $ "$GH" release -R "$VERIFIER_REPOSITORY" upload "$VERIFIER_TAG" slsa-verifier-linux-amd64
+   ```shell
+   echo hello > slsa-verifier-linux-amd64
+   "$GH" release -R "$VERIFIER_REPOSITORY" upload "$VERIFIER_TAG" slsa-verifier-linux-amd64
    ```
 
 1. Ensure your fork of the builder is at the same commit hash as the offical builder's `$BUILDER_TAG` release.
@@ -95,7 +96,7 @@ There is one integration test we cannot easily test "live", so we need to simula
 1. Create a release for the builders for this branch:
 
    ```shell
-   $ "$GH" release -R "$BUILDER_REPOSITORY" create "$BUILDER_TAG" --title "$BUILDER_TAG" --notes "pre-release tests for $BUILDER_TAG $(date)" --target "$BUILDER_REF"
+   "$GH" release -R "$BUILDER_REPOSITORY" create "$BUILDER_TAG" --title "$BUILDER_TAG" --notes "pre-release tests for $BUILDER_TAG $(date)" --target "$BUILDER_REF"
    ```
 
    This will trigger a workflow release, let it complete and generate the release assets.
@@ -141,15 +142,15 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 1. Make sure you have downloaded the `$BUILDER_TAG` builder's binary locally `slsa-builder-go-linux-amd64`, either via the web UI or via:
 
    ```shell
-   $ "$GH" release -R slsa-framework/slsa-github-generator download "$BUILDER_TAG" -p "slsa-builder-go-linux-amd64"
-   $ mv slsa-builder-go-linux-amd64 slsa-builder-go-linux-amd64-"$BUILDER_TAG".original
+   "$GH" release -R slsa-framework/slsa-github-generator download "$BUILDER_TAG" -p "slsa-builder-go-linux-amd64"
+   mv slsa-builder-go-linux-amd64 slsa-builder-go-linux-amd64-"$BUILDER_TAG".original
    ```
 
 1. Upload a different binary to the assets:
 
    ```shell
-   $ echo hello > slsa-builder-go-linux-amd64
-   $ "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-builder-go-linux-amd64  --clobber
+   echo hello > slsa-builder-go-linux-amd64
+   "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-builder-go-linux-amd64  --clobber
    ```
 
 1. Update the version of the workflow [slsa-framework/example-package/.github/workflows/e2e.go.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml#L14](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/e2e.go.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml#L14) with the `$BUILDER_TAG` to test.
@@ -167,8 +168,8 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 1. If the test above failed with the expected message, re-upload the original binary back to the assets, e.g. via:
 
    ```shell
-   $ mv slsa-builder-go-linux-amd64-"$BUILDER_TAG".original slsa-builder-go-linux-amd64
-   $ "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-builder-go-linux-amd64  --clobber
+   mv slsa-builder-go-linux-amd64-"$BUILDER_TAG".original slsa-builder-go-linux-amd64
+   "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-builder-go-linux-amd64  --clobber
    ```
 
 1. Re-run the workflow above and verify that it succeeds. (TODO: https://github.com/slsa-framework/slsa-github-generator/issues/116).
@@ -180,15 +181,15 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 1. Make sure you have downloaded the `$BUILDER_TAG` builder's binary locally `slsa-generator-generic-linux-amd64`, either via the web UI or via:
 
    ```shell
-   $ "$GH" release -R slsa-framework/slsa-github-generator download "$BUILDER_TAG" -p "slsa-generator-generic-linux-amd64"
-   $ mv slsa-generator-generic-linux-amd64 slsa-generator-generic-linux-amd64-"$BUILDER_TAG".original
+   "$GH" release -R slsa-framework/slsa-github-generator download "$BUILDER_TAG" -p "slsa-generator-generic-linux-amd64"
+   mv slsa-generator-generic-linux-amd64 slsa-generator-generic-linux-amd64-"$BUILDER_TAG".original
    ```
 
 1. Upload a different binary to the assets:
 
    ```shell
-   $ echo hello > slsa-generator-generic-linux-amd64
-   $ "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-generator-generic-linux-amd64  --clobber
+   echo hello > slsa-generator-generic-linux-amd64
+   "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-generator-generic-linux-amd64  --clobber
    ```
 
 1. Update the version of the workflow [slsa-framework/example-package/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml#L35](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml#L35) with the `$BUILDER_TAG` to test.
@@ -206,8 +207,8 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 1. If the test above failed with the expected message, re-upload the original binary back to the assets, e.g. via:
 
    ```shell
-   $ mv slsa-generator-generic-linux-amd64-"$BUILDER_TAG".original slsa-generator-generic-linux-amd64
-   $ "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-generator-generic-linux-amd64  --clobber
+   mv slsa-generator-generic-linux-amd64-"$BUILDER_TAG".original slsa-generator-generic-linux-amd64
+   "$GH" release -R slsa-framework/slsa-github-generator upload "$BUILDER_TAG" slsa-generator-generic-linux-amd64  --clobber
    ```
 
 1. Re-run the workflow above and verify that it succeeds. (TODO: https://github.com/slsa-framework/slsa-github-generator/issues/116).
@@ -249,7 +250,7 @@ Untick the `This is a pre-release` option.
 Update the documentation to recommend using the new version:
 
 ```shell
-$ find . -name "*.md" -exec sed -i "s/v1.0.0/v1.1.1/g" {} +
+find . -name "*.md" -exec sed -i "s/v1.0.0/v1.1.1/g" {} +
 ```
 
 ## Send a PR to reference Actions at main

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,8 @@ Tick the `This is a pre-release` option.
 
 Click `Publish release`.
 
+This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Cancel this in the [UI](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml).
+
 ## Verify version references
 
 Update version references with the following command:
@@ -57,9 +59,14 @@ Send a PR with this update and add `#label:release ${BUILDER_TAG}` in the PR des
 
 Once the PR is merged, update the tag to point to HEAD.
 
-## Pre-release tests
+```shell
+git tag v1.2.2 -f
+git push v1.2.2 -f
+```
 
-Verify the references to the internal Actions by manually running the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds.
+This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds and that the release assets are updated.
+
+## Pre-release tests
 
 There is one integration test we cannot easily test "live", so we need to simulate it by changing the code: malicious verifier binary in assets. We want to be sure the builder fails if the verifier's binary is tampered with. For this:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,10 +4,12 @@ This is a document to describe the release process for the Go builder. Since all
 
 ---
 
-- [Pre-release](#pre-release-tests)
+- [Prerequisites](#prerequisites)
 - [Tagging](#tagging)
-- [Verify version references & code freeze](#verify-version-references--code-freeze)
+- [Verify version references](#verify-version-references)
+- [Pre-release Tests](#pre-release-tests)
 - [Post-release tests](#post-release-tests)
+- [Code Freeze](#code-freeze)
 - [Update Verifier](#update-verifier)
 - [Finalize release](#finalize-release)
 - [Announce](#announce)
@@ -43,7 +45,7 @@ Tick the `This is a pre-release` option.
 
 Click `Publish release`.
 
-## Verify version references & code freeze
+## Verify version references
 
 Update version references with the following command:
 
@@ -54,10 +56,6 @@ find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: 
 Send a PR with this update and add `#label:release ${BUILDER_TAG}` in the PR description.
 
 Once the PR is merged, update the tag to point to HEAD.
-
-Code freeze the repository for 1-2 days.
-
-Verify all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
 
 ## Pre-release tests
 
@@ -215,6 +213,12 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 1. Re-run the workflow above and verify that it succeeds. (TODO: https://github.com/slsa-framework/slsa-github-generator/issues/116).
 
    If it does not, delete the release, fix the bug and re-start the release process at the top of this page.
+
+## Code Freeze
+
+Code freeze the repository for 1-2 days.
+
+After the code freeze, verify all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
 
 ## Update verifier
 


### PR DESCRIPTION
Updates the release docs.

1. Tagging happens at the beginning in order to update workflow reference. This means that Pre and Post release tests can be run in sequence before code-freeze and ensures we don't wait to find errors in release tests.
2. Updated commands to be easier to copy & paste.

Signed-off-by: Ian Lewis <ianlewis@google.com>