### PR TITLE
builder: go: Allow equal signs in env vars

### DIFF
--- a/internal/builders/go/pkg/config.go
+++ b/internal/builders/go/pkg/config.go
@@ -167,11 +167,11 @@ func validateVersion(cf *goReleaserConfigFile) error {
 func (r *GoReleaserConfig) setEnvs(cf *goReleaserConfigFile) error {
 	m := make(map[string]string)
 	for _, e := range cf.Env {
-		es := strings.Split(e, "=")
-		if len(es) != 2 {
+		name, value, present := strings.Cut(e, "=")
+		if !present {
 			return fmt.Errorf("%w: %s", ErrorInvalidEnvironmentVariable, e)
 		}
-		m[es[0]] = es[1]
+		m[name] = value
 	}
 
 	if len(m) > 0 {

--- a/internal/builders/go/pkg/config_test.go
+++ b/internal/builders/go/pkg/config_test.go
@@ -75,6 +75,32 @@ func Test_ConfigFromFile(t *testing.T) {
 			},
 		},
 		{
+			name: "valid env var with no value",
+			path: "./testdata/releaser-valid-envs-no-value.yml",
+			config: GoReleaserConfig{
+				Goos: "linux", Goarch: "amd64",
+				Flags:   []string{"-trimpath", "-tags=netgo"},
+				Ldflags: []string{"{{ .Env.VERSION_LDFLAGS }}"},
+				Binary:  "binary-{{ .OS }}-{{ .Arch }}",
+				Env: map[string]string{
+					"GO111MODULE": "on", "CGO_ENABLED": "0", "CGO_CFLAGS": "",
+				},
+			},
+		},
+		{
+			name: "valid env var with multiple = signs",
+			path: "./testdata/releaser-valid-envs-multiple-equal-signs.yml",
+			config: GoReleaserConfig{
+				Goos: "linux", Goarch: "amd64",
+				Flags:   []string{"-trimpath", "-tags=netgo"},
+				Ldflags: []string{"{{ .Env.VERSION_LDFLAGS }}"},
+				Binary:  "binary-{{ .OS }}-{{ .Arch }}",
+				Env: map[string]string{
+					"GO111MODULE": "on", "CGO_ENABLED": "0", "CGO_CFLAGS": "a=b=c",
+				},
+			},
+		},
+		{
 			name: "missing version",
 			path: "./testdata/releaser-noversion.yml",
 			err:  ErrorUnsupportedVersion,

--- a/internal/builders/go/pkg/testdata/releaser-valid-envs-multiple-equal-signs.yml
+++ b/internal/builders/go/pkg/testdata/releaser-valid-envs-multiple-equal-signs.yml
@@ -1,0 +1,16 @@
+version: 1
+env:
+  - GO111MODULE=on
+  # https://stackoverflow.com/a/62821358/19407
+  - CGO_ENABLED=0
+  - CGO_CFLAGS=a=b=c
+
+flags:
+  - -trimpath
+  - -tags=netgo
+
+goos: linux
+goarch: amd64
+binary: binary-{{ .OS }}-{{ .Arch }}
+ldflags:
+  - "{{ .Env.VERSION_LDFLAGS }}"

--- a/internal/builders/go/pkg/testdata/releaser-valid-envs-no-value.yml
+++ b/internal/builders/go/pkg/testdata/releaser-valid-envs-no-value.yml
@@ -1,0 +1,16 @@
+version: 1
+env:
+  - GO111MODULE=on
+  # https://stackoverflow.com/a/62821358/19407
+  - CGO_ENABLED=0
+  - CGO_CFLAGS=
+
+flags:
+  - -trimpath
+  - -tags=netgo
+
+goos: linux
+goarch: amd64
+binary: binary-{{ .OS }}-{{ .Arch }}
+ldflags:
+  - "{{ .Env.VERSION_LDFLAGS }}"


### PR DESCRIPTION
If .slsa-goreleaser.yml contains an env var with multiple '=' signs:
```
env:
  - CGO_ENABLED=1
  - CGO_CFLAGS=-mmacosx-version-min=11.0
```

the 'build dry project' GH workflow step fails with "invalid environment
variable: CGO_CFLAGS=-mmacosx-version-min=11.0"
This is caused by the way the env vars are parsed in GoReleaserConfig:setEnvs
which only allow for a single '=' sign.

This commit fixes this by splitting the env string at the first equal sign,
first part is the env var name and won't contain '=' signs, second part
is its value and can contain any number of '='.

This also adds unit tests for this situation, and for env vars with no
values (`CGO_CFLAGS=`).

This fixes https://github.com/slsa-framework/slsa-github-generator/issues/1231