### PR TITLE
[go] [generic] add pull request support without signing

### DIFF
--- a/github/oidc.go
+++ b/github/oidc.go
@@ -126,6 +126,13 @@ func NewOIDCClient() (*OIDCClient, error) {
 	return &c, nil
 }
 
+// HasOIDCClient detects whether the environment has access to request an
+// OIDC token.
+func HasOIDCClient() bool {
+	_, ok := os.LookupEnv(requestURLEnvKey)
+	return ok
+}
+
 func (c *OIDCClient) newRequestURL(audience []string) string {
 	requestURL := *c.requestURL
 	q := requestURL.Query()

--- a/github/oidc_test.go
+++ b/github/oidc_test.go
@@ -234,7 +234,7 @@ func TestToken(t *testing.T) {
 			token, err := c.Token(context.Background(), tc.audience)
 			if err != nil {
 				if tc.err != nil {
-					if !errors.As(err, &tc.err) {
+					if !errors.As(err, tc.err) {
 						t.Fatalf("unexpected error: %v", cmp.Diff(err, tc.err, cmpopts.EquateErrors()))
 					}
 				} else {

--- a/internal/builders/go/pkg/provenance_test.go
+++ b/internal/builders/go/pkg/provenance_test.go
@@ -26,6 +26,7 @@ func TestGenerateProvenance_withErr(t *testing.T) {
 	// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
 	t.Setenv("GITHUB_EVENT_NAME", "non_event")
 	t.Setenv("GITHUB_CONTEXT", "{}")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "something")
 	sha256 := "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2"
 	_, err := GenerateProvenance("foo", sha256, "", "", "/home/foo", &testutil.TestSigner{}, &testutil.TransparencyLogWithErr{}, &slsa.NilClientProvider{})
 	if want, got := testutil.ErrTransparencyLog, err; want != got {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

1. Should we display some github log warning?
2. This sort of makes the check `IsPresubmitTest` not necessary. Is that OK? I'm not sure if we want to continue gating on that, or maybe we want to add an explicit flag to users like "snapshot" that is required to allow pull_requests to generate the predicate (that way users don't accidentally generate unsigned provenance)
