### PR TITLE
Fix grep

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -112,7 +112,8 @@ jobs:
         env:
           BODY: "${{ github.event.pull_request.body }}"
         run: |
-          RELEASE_TAG=$(echo "$BODY" | grep -oe '#label:release .*' | grep -oe 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          # match the first instance of a line with 'label:release vX.Y.Z' with only leading or trailing whitespace.
+          RELEASE_TAG=$(echo "$BODY" | sed -n '0,/^#label:release/ s/^#label:release\s*//p' | grep -oe '^v[0-9]\+\.[0-9]\+\.[0-9]\+[[:space:]]*$')
           RELEASE_TAG=${RELEASE_TAG} ./__THIS_REPO__/.github/workflows/scripts/pre-release/references.sh
 
   secure-project-checkout-go:

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -112,7 +112,7 @@ jobs:
         env:
           BODY: "${{ github.event.pull_request.body }}"
         run: |
-          RELEASE_TAG=$(echo "$BODY" | grep -o -e 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          RELEASE_TAG=$(echo "$BODY" | grep -o -e '#label:release .*' | grep -oe 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
           RELEASE_TAG=${RELEASE_TAG} ./__THIS_REPO__/.github/workflows/scripts/pre-release/references.sh
 
   secure-project-checkout-go:

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -112,7 +112,7 @@ jobs:
         env:
           BODY: "${{ github.event.pull_request.body }}"
         run: |
-          RELEASE_TAG=$(echo "$BODY" | grep -o -e '#label:release .*' | grep -oe 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          RELEASE_TAG=$(echo "$BODY" | grep -oe '#label:release .*' | grep -oe 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
           RELEASE_TAG=${RELEASE_TAG} ./__THIS_REPO__/.github/workflows/scripts/pre-release/references.sh
 
   secure-project-checkout-go:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -669,6 +669,7 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
 
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
@@ -696,7 +697,7 @@ jobs:
     permissions:
       actions: read
       id-token: write
-      contents: read
+      contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"


### PR DESCRIPTION
Fixes the pre-release references check to match the version tag on the label:release label. This fixes buggy behavior when the pull request body includes multiple semver version numbers in the text.

Signed-off-by: Ian Lewis <ianlewis@google.com>