### PR TITLE
Fix docs for goreleaser with the generic generator to include docker di…

### DIFF
--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -325,7 +325,7 @@ generate SLSA3 provenance by updating your existing workflow with the steps indi
 **Notes**:
 - Make sure you did not disable checksum generation in the goreleaser yml.
 - Make sure you specified sha256 as the algorithm for the checksum or left it empty (sha256 is the default).
-- To enable provenance generation for dockers (as well as artifacts), use goreleaser version >= v1.13.0.
+- To enable provenance generation for dockers (as well as artifacts), use [goreleaser version >= v1.13.0](https://github.com/goreleaser/goreleaser/releases/tag/v1.13.0).
 
 1. Declare an `outputs` for the GoReleaser job:
 

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -322,6 +322,11 @@ This section explains how to generate non-forgeable SLSA provenance with existin
 If you use [GoReleaser](https://github.com/goreleaser/goreleaser-action) to generate your build, you can easily
 generate SLSA3 provenance by updating your existing workflow with the steps indicated in the workflow below:
 
+**Notes**:
+- Make sure you did not disable checksum generation in the goreleaser yml.
+- Make sure you specified sha256 as the algorithm for the checksum or left it empty (sha256 is the default).
+- To enable provenance generation for dockers (as well as artifacts), use goreleaser version >= v1.13.0.
+
 1. Declare an `outputs` for the GoReleaser job:
 
 ```yaml
@@ -331,7 +336,7 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
 ```
 
-2. Add an `id: run-goreleaser` field to your goreleaser step. Use goreleaser version >= v1.13.0 to enable provenance generation for dockers.
+2. Add an `id: run-goreleaser` field to your goreleaser step:
 
 ```yaml
     steps:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -338,7 +338,7 @@ jobs:
       [...]
       - name: Run GoReleaser
         id: run-goreleaser
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # tag=v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # tag=v3.2.0
 
 ```
 
@@ -351,9 +351,8 @@ jobs:
     ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
   run: |
     set -euo pipefail
-
-    checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-    echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+    hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+    echo "hashes=$hashes" >> $GITHUB_OUTPUT
 ```
 
 4. Call the generic workflow to generate provenance by declaring the job below:


### PR DESCRIPTION
goreleaser [latest release](https://github.com/goreleaser/goreleaser/releases/tag/v1.13.0) includes a couple of new features that are useful for provenance generation:

* https://github.com/goreleaser/goreleaser/commit/5eb1e4ad0d41c6ee06db34183689a42e02a77fe0: feat: add digest to artifacts info of published docker images (https://github.com/goreleaser/goreleaser/pull/3540) (@gal-legit)
* https://github.com/goreleaser/goreleaser/commit/76dc0b559e073eca268700cc5799c1f00ffdf466: feat: output checksums to artifacts info (https://github.com/goreleaser/goreleaser/pull/3548) (@gal-legit)

The first one (published docker images) actually enables users to include the built dockers in their provenance documents.
The second one (checksums) is added mainly to simplify the usage.

This pull request updates the instructions in the documentation for the generic builder with goreleaser, to take advantage of these new features. 