### PR TITLE
Update GHA token permissions for generic container workflow

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -14,6 +14,9 @@
 
 name: SLSA container image provenance
 
+permissions:
+  contents: read
+
 env:
   # Generator
   BUILDER_BINARY: slsa-generator-container-linux-amd64 # Name of the binary in the release assets.
@@ -79,7 +82,7 @@ jobs:
     permissions:
       id-token: write # Needed to get OIDC token for keyless signing.
       actions: read # Needed to read workflow info.
-      packages: write # Needed to login and upload attestations to ghcr.io.
+      # packages: write # Needed to login and upload attestations to ghcr.io.
     steps:
       - name: Generate builder
         uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v1.3.0

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -14,8 +14,7 @@
 
 name: SLSA container image provenance
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   # Generator

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -81,7 +81,6 @@ jobs:
     permissions:
       id-token: write # Needed to get OIDC token for keyless signing.
       actions: read # Needed to read workflow info.
-      # packages: write # Needed to login and upload attestations to ghcr.io.
     steps:
       - name: Generate builder
         uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v1.3.0

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -163,7 +163,6 @@ For more information about this design decision and how to configure renovatebot
 In order to use the GitHub Container Registry (ghcr.io) you will need to
 authenticate using a
 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-
 (PAT). The PAT must have at least `packages:write` permissions if using a
 classic PAT.
 

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -19,6 +19,7 @@ project simply generates provenance as a separate step in an existing workflow.
 - [Generating Provenance](#generating-provenance)
   - [Getting Started](#getting-started)
   - [Referencing the SLSA generator](#referencing-the-slsa-generator)
+  - [GitHub Container Registry](#github-container-registry)
   - [Private Repositories](#private-repositories)
   - [Supported Triggers](#supported-triggers)
   - [Workflow Inputs](#workflow-inputs)
@@ -66,7 +67,6 @@ provenance:
   permissions:
     actions: read # for detecting the Github Actions environment.
     id-token: write # for creating OIDC tokens for signing.
-    packages: write # for uploading attestations.
   if: startsWith(github.ref, 'refs/tags/')
   # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Use a tagged release once we have one.
   uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@main
@@ -77,7 +77,7 @@ provenance:
     # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
     compile-generator: true
   secrets:
-    registry-password: ${{ secrets.GITHUB_TOKEN }}
+    registry-password: ${{ secrets.PAT_TOKEN }}
 ```
 
 Here's an example of what it might look like all together.
@@ -92,7 +92,6 @@ jobs:
   build:
     permissions:
       contents: read
-      packages: write
     outputs:
       image: ${{ steps.image.outputs.image }}
       digest: ${{ steps.build.outputs.digest }}
@@ -109,7 +108,7 @@ jobs:
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PAT_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -140,7 +139,6 @@ jobs:
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
-      packages: write # for uploading attestations.
     if: startsWith(github.ref, 'refs/tags/')
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@main
     with:
@@ -150,7 +148,7 @@ jobs:
       # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/492): Remove after GA release.
       compile-generator: true
     secrets:
-      registry-password: ${{ secrets.GITHUB_TOKEN }}
+      registry-password: ${{ secrets.PAT_TOKEN }}
 ```
 
 ### Referencing the SLSA generator
@@ -159,6 +157,15 @@ At present, the generator **MUST** be referenced
 by a tag of the form `@vX.Y.Z`, because the build will fail if you reference it via a shorter tag like `@vX.Y` or `@vX` or if you reference it by a hash.
 
 For more information about this design decision and how to configure renovatebot,see the main repository [README.md](../../../README.md).
+
+### GitHub Container Registry
+
+In order to use the GitHub Container Registry (ghcr.io) you will need to
+authenticate using a
+[personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+(PAT). The PAT must have at least `packages:write` permissions if using a
+classic PAT.
 
 ### Private Repositories
 
@@ -320,13 +327,13 @@ jobs:
 
 ```yaml
 steps:
-  [...]
+  # [...]
   - name: Run ko
     id: build
     env:
       KO_DOCKER_REPO: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
       KO_USER: ${{ github.actor }}
-      KO_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      KO_PASSWORD: ${{ secrets.PAT_TOKEN }}
       GIT_REF: ${{ github.ref }}
     run: |
       # get tag name without tags/refs/ prefix.
@@ -353,8 +360,6 @@ provenance:
   permissions:
     actions: read
     id-token: write
-    # contents: read
-    packages: write
   if: startsWith(github.ref, 'refs/tags/')
   # TODO: Update after GA
   # uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.2.0
@@ -365,7 +370,7 @@ provenance:
     registry-username: ${{ github.actor }}
     compile-generator: true
   secrets:
-    registry-password: ${{ secrets.GITHUB_TOKEN }}
+    registry-password: ${{ secrets.PAT_TOKEN }}
 ```
 
 All together, it will look as the following:
@@ -375,7 +380,6 @@ jobs:
   build:
     permissions:
       contents: read
-      packages: write
     outputs:
       image: ${{ steps.build.outputs.image }}
       digest: ${{ steps.build.outputs.digest }}
@@ -396,7 +400,7 @@ jobs:
         env:
           KO_DOCKER_REPO: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
           KO_USER: ${{ github.actor }}
-          KO_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          KO_PASSWORD: ${{ secrets.PAT_TOKEN }}
           GIT_REF: ${{ github.ref }}
         run: |
           # get tag name without tags/refs/ prefix.
@@ -420,8 +424,6 @@ jobs:
     permissions:
       actions: read
       id-token: write
-      # contents: read
-      packages: write
     if: startsWith(github.ref, 'refs/tags/')
     # uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.2.0
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@9dc6318aedc3d24ede4e946966d30c752769a4f9
@@ -431,7 +433,7 @@ jobs:
       registry-username: ${{ github.actor }}
       compile-generator: true
     secrets:
-      registry-password: ${{ secrets.GITHUB_TOKEN }}
+      registry-password: ${{ secrets.PAT_TOKEN }}
 ```
 
 ## Verification


### PR DESCRIPTION
Fixes #1256 
Fixes #1257 
Updates #547 

1. Sets top level token permissions for the container generator workflow.
2. Updates container generator workflow to no longer require `package: write` permissions on the GHA token. Instead we require users of ghcr.io to login using a PAT.