### PR TITLE
Exclude go from renovate PR grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     },
     {
       "matchManagers": ["gomod"],
+      "excludePackageNames": ["go"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "go"
     },


### PR DESCRIPTION
Update renovate config so that Go itself is updated in it's own PR rather than being grouped together with Go packages.

Signed-off-by: Ian Lewis <ianlewis@google.com>