### PR TITLE
Update references check to support pre-release

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -113,7 +113,7 @@ jobs:
           BODY: "${{ github.event.pull_request.body }}"
         run: |
           # match the first instance of a line with 'label:release vX.Y.Z' with only leading or trailing whitespace.
-          RELEASE_TAG=$(echo "$BODY" | sed -n '0,/^#label:release/ s/^#label:release\s*//p' | grep -oe '^v[0-9]\+\.[0-9]\+\.[0-9]\+[[:space:]]*$')
+          RELEASE_TAG=$(echo "$BODY" | grep -oe '^[[:space:]]*#label:release[[:space:]]*v[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?[[:space:]]*$' | head -n1 | sed -n 's/^#label:release\s*//p')
           RELEASE_TAG=${RELEASE_TAG} ./__THIS_REPO__/.github/workflows/scripts/pre-release/references.sh
 
   secure-project-checkout-go:

--- a/.github/workflows/scripts/pre-release/references.sh
+++ b/.github/workflows/scripts/pre-release/references.sh
@@ -13,22 +13,23 @@ source "./.github/workflows/scripts/e2e-utils.sh"
 major=$(version_major "$RELEASE_TAG")
 minor=$(version_minor "$RELEASE_TAG")
 patch=$(version_patch "$RELEASE_TAG")
+rc=$(version_rc "$RELEASE_TAG")
 echo "\"$RELEASE_TAG\" follows semver:"
 echo "major: $major"
 echo "minor: $minor"
 echo "patch: $patch"
+echo "rc: $rc"
 cd -
 
 # Verify internal Actions are referenced by the release tag.
 cd __THIS_REPO__
 results=$(
-    find .github/workflows/ -maxdepth 1 -type f -print0 -name '*.yaml' -o -name '*.yml' \
-    | xargs -0 grep -P "slsa-framework/slsa-github-generator/.github/actions/.*@(?!$RELEASE_TAG)" \
-    || true
+    find .github/workflows/ -maxdepth 1 -type f -print0 -name '*.yaml' -o -name '*.yml' |
+        xargs -0 grep -P "slsa-framework/slsa-github-generator/.github/actions/.*@(?!$RELEASE_TAG)" ||
+        true
 )
 if [[ "$results" != "" ]]; then
     echo "Some Actions are not referenced via the correct release tag \"$RELEASE_TAG\""
     echo "$results"
     exit 1
 fi
-


### PR DESCRIPTION
Pre-releases will use tags of the form `vX.Y.Z-rc.A`. This updates the references check to match against these tags.

example-package was updated to support pre-release tags in this commit: https://github.com/slsa-framework/example-package/commit/87b1f459668c9e0e7e2a9129c794c1dc3b2b6dc9


Signed-off-by: Ian Lewis <ianlewis@google.com>