### PR TITLE
Revert package perms

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -14,8 +14,6 @@
 
 name: SLSA container image provenance
 
-permissions: {}
-
 env:
   # Generator
   BUILDER_BINARY: slsa-generator-container-linux-amd64 # Name of the binary in the release assets.
@@ -81,6 +79,7 @@ jobs:
     permissions:
       id-token: write # Needed to get OIDC token for keyless signing.
       actions: read # Needed to read workflow info.
+      packages: write # Needed to login and upload attestations to ghcr.io.
     steps:
       - name: Generate builder
         uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v1.4.0-rc.0

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -14,6 +14,8 @@
 
 name: SLSA container image provenance
 
+permissions: {}
+
 env:
   # Generator
   BUILDER_BINARY: slsa-generator-container-linux-amd64 # Name of the binary in the release assets.


### PR DESCRIPTION
Reopens #1257 

Reverts most of #1258 but leaves in place top level permissions for the generic container workflow. This is because cosign seems to use the ambient token to retrieve data from the OCI registry for signing rather than using the provided registry password.