### PR TITLE
docs: Add documentation on matrix-strategy builds

### DIFF
--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -26,6 +26,7 @@ project simply generates provenance as a separate step in an existing workflow.
   - [Provenance Example](#provenance-example)
 - [Integration With Other Build Systems](#integration-with-other-build-systems)
   - [Ko](#ko)
+- [Provenance for matrix strategy builds](#provenance-for-matrix-strategy-builds)
 - [Verification](#verification)
   - [Cosign](#cosign)
   - [Sigstore policy-controller](#sigstore-policy-controller)
@@ -433,6 +434,12 @@ jobs:
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+## Provenance for matrix strategy builds
+
+See the
+[equivalent section](../generic/README.md#provenance-for-matrix-strategy-builds)
+for the generic generator.
 
 ## Verification
 

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -15,30 +15,31 @@ project simply generates provenance as a separate step in an existing workflow.
 
 ---
 
-- [Benefits of Provenance](#benefits-of-provenance)
-- [Generating Provenance](#generating-provenance)
-  - [Getting Started](#getting-started)
-  - [Referencing the SLSA generator](#referencing-the-slsa-generator)
-  - [Private Repositories](#private-repositories)
-  - [Supported Triggers](#supported-triggers)
-  - [Workflow Inputs](#workflow-inputs)
-  - [Workflow Outputs](#workflow-outputs)
-  - [Provenance Format](#provenance-format)
-  - [Provenance Example](#provenance-example)
-- [Integration With Other Build Systems](#integration-with-other-build-systems)
-  - [Provenance for GoReleaser](#provenance-for-goreleaser)
-  - [Provenance for Bazel](#provenance-for-bazel)
-  - [Provenance for Java](#provenance-for-java)
-    - [Maven](#maven)
-    - [Gradle](#gradle)
-  - [Provenance for Rust](#provenance-for-rust)
-  - [Provenance for Haskell](#provenance-for-haskell)
-  - [Provenance for Python](#provenance-for-python)
-- [Provenance for matrix strategy builds](#provenance-for-matrix-strategy-builds)
-  - [A single provenance attestation for all artifacts](#a-single-provenance-attestation-for-all-artifacts)
-  - [A different attestation for each iteration](#a-different-attestation-for-each-iteration)
-- [Known Issues](#known-issues)
-  - [error updating to TUF remote mirror: tuf: invalid key](#error-updating-to-tuf-remote-mirror-tuf-invalid-key)
+- [Generation of SLSA3+ provenance for arbitrary projects](#generation-of-slsa3-provenance-for-arbitrary-projects)
+  - [Benefits of Provenance](#benefits-of-provenance)
+  - [Generating Provenance](#generating-provenance)
+    - [Getting Started](#getting-started)
+    - [Referencing the SLSA generator](#referencing-the-slsa-generator)
+    - [Private Repositories](#private-repositories)
+    - [Supported Triggers](#supported-triggers)
+    - [Workflow Inputs](#workflow-inputs)
+    - [Workflow Outputs](#workflow-outputs)
+    - [Provenance Format](#provenance-format)
+    - [Provenance Example](#provenance-example)
+  - [Integration With Other Build Systems](#integration-with-other-build-systems)
+    - [Provenance for GoReleaser](#provenance-for-goreleaser)
+    - [Provenance for Bazel](#provenance-for-bazel)
+    - [Provenance for Java](#provenance-for-java)
+      - [Maven](#maven)
+      - [Gradle](#gradle)
+    - [Provenance for Rust](#provenance-for-rust)
+    - [Provenance for Haskell](#provenance-for-haskell)
+    - [Provenance for Python](#provenance-for-python)
+  - [Provenance for matrix strategy builds](#provenance-for-matrix-strategy-builds)
+    - [A single provenance attestation for all artifacts](#a-single-provenance-attestation-for-all-artifacts)
+    - [A different attestation for each iteration](#a-different-attestation-for-each-iteration)
+  - [Known Issues](#known-issues)
+    - [error updating to TUF remote mirror: tuf: invalid key](#error-updating-to-tuf-remote-mirror-tuf-invalid-key)
 
 ---
 
@@ -1095,7 +1096,7 @@ variable.
 ```
 
 5. The provenance job is also effectively identical to the examples above,
-except that relies on `combine_hashes` instead of the `build` job.
+except that it relies on `combine_hashes` instead of the `build` job.
 
 ```yml
   provenance:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -29,10 +29,16 @@ project simply generates provenance as a separate step in an existing workflow.
   - [Provenance for GoReleaser](#provenance-for-goreleaser)
   - [Provenance for Bazel](#provenance-for-bazel)
   - [Provenance for Java](#provenance-for-java)
+    - [Maven](#maven)
+    - [Gradle](#gradle)
   - [Provenance for Rust](#provenance-for-rust)
   - [Provenance for Haskell](#provenance-for-haskell)
   - [Provenance for Python](#provenance-for-python)
+- [Provenance for matrix strategy builds](#provenance-for-matrix-strategy-builds)
+  - [A single provenance attestation for all artifacts](#a-single-provenance-attestation-for-all-artifacts)
+  - [A different attestation for each permutation](#a-different-attestation-for-each-permutation)
 - [Known Issues](#known-issues)
+  - [error updating to TUF remote mirror: tuf: invalid key](#error-updating-to-tuf-remote-mirror-tuf-invalid-key)
 
 ---
 
@@ -923,7 +929,7 @@ jobs:
     runs-on: "ubuntu-latest"    
     environment:      
       name: "publish"
-      outputs:
+    outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
 ```
 
@@ -1010,6 +1016,231 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true # Optional: Upload to a new release
+```
+
+## Provenance for matrix strategy builds
+
+If you're building with a matrix strategy, there's a bit of necessary
+boilerplate.
+
+There are a few ways to handle provenance for matrix builds. You can create a
+single provenance file describing all the artifacts from the different
+iterations or a different file for each iteration's artifact(s).
+
+### A single provenance attestation for all artifacts
+
+1. As with the examples above, the first thing to do is define the build job,
+with its outputs and now its matrix strategy.  
+  
+GitHub currently doesn't support different outputs for matrix builds. We must
+therefore declare a different hash output for each permutation. A follow-up job
+will collate all the hashes into a single string.
+
+```yml
+jobs:
+  build:
+    strategy:
+      matrix:
+        color: ["red", "blue", "green"]
+        flavor: ["mint", "vanilla"]
+    outputs:
+      # The key-names are actually irrelevant, but keep them descriptive
+      hash-red-mint:      ${{ steps.hash.outputs.hash-red-mint }}
+      hash-red-vanilla:   ${{ steps.hash.outputs.hash-red-vanilla }}
+      hash-blue-mint:     ${{ steps.hash.outputs.hash-blue-mint }}
+      hash-blue-vanilla:  ${{ steps.hash.outputs.hash-blue-vanilla }}
+      hash-green-mint:    ${{ steps.hash.outputs.hash-green-mint }}
+      hash-green-vanilla: ${{ steps.hash.outputs.hash-green-vanilla }}
+````
+
+2. You'll now have to build your project as usual:
+
+```yml
+    steps:
+      # whatever you need to do to build (checkout, setup the environment,
+      # get dependencies, compile...)
+      - ...
+      - ...
+      - ...
+```
+
+3. As with the other examples, you'll then have to generate the hashes that
+represent your build. This step is effectively identical to all the examples
+above, except each permutation must store its hash in a different output
+variable.
+
+```yml
+      - name: Generate subject
+        id: hash
+        run: |
+          echo "hash-${{ matrix.color }}-${{ matrix.flavor }}=$( \
+            sha256sum ... | base64 -w0 \
+          )" >> "$GITHUB_OUTPUT"
+```
+
+4. Now you'll collate all the individual hashes into a single bas64 string.
+
+```yml
+  combine_hashes:
+    needs: [build]
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
+    env:
+      HASHES: ${{ toJSON(needs.build.outputs) }}
+    steps:
+      - id: hashes
+        run: |
+          echo "$HASHES" | jq -r '.[] | @base64d' | sed "/^$/d" > hashes.txt
+          echo "hashes=$(cat hashes.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+```
+
+5. The provenance job is also effectively identical to the examples above,
+except that it `needs: [combine_hashes]` instead of the `build` job.
+
+```yml
+  provenance:
+    needs: [combine_hashes]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
+      upload-assets: true # Optional: Upload to a new release
+```
+
+Now all together:
+
+```yml
+jobs:
+  build:
+    strategy:
+      matrix:
+        color: ["red", "blue", "green"]
+        flavor: ["mint", "vanilla"]
+    outputs:
+      hash-red-mint:      ${{ steps.hash.outputs.hash-red-mint }}
+      hash-red-vanilla:   ${{ steps.hash.outputs.hash-red-vanilla }}
+      hash-blue-mint:     ${{ steps.hash.outputs.hash-blue-mint }}
+      hash-blue-vanilla:  ${{ steps.hash.outputs.hash-blue-vanilla }}
+      hash-green-mint:    ${{ steps.hash.outputs.hash-green-mint }}
+      hash-green-vanilla: ${{ steps.hash.outputs.hash-green-vanilla }}
+    steps:
+      # all your build steps
+      - ...
+      - ...
+      - ...
+
+      - name: Generate subject
+        id: hash
+        run: |
+          echo "hash-${{ matrix.color }}-${{ matrix.flavor }}=$( \
+            sha256sum ... | base64 -w0 \
+          )" >> "$GITHUB_OUTPUT"
+
+  combine_hashes:
+    needs: [build]
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
+    env:
+      HASHES: ${{ toJSON(needs.build.outputs) }}
+    steps:
+      - id: hashes
+        run: |
+          echo "$HASHES" | jq -r '.[] | @base64d' | sed "/^$/d" > hashes.txt
+          echo "hashes=$(cat hashes.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [combine_hashes]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
+      upload-assets: true # Optional: Upload to a new release
+```
+
+This will create a single provenance file that describes all of the built
+artifacts. The default name will be `multiple.intoto.jsonl`, but can be modified
+by passing the `provenance-name` argument to the generator.
+
+Should your build job require other outputs (not just the hashes, but other
+values such as the artifact name, for example), you'll need to change the `jq`
+command within the `combine_hashes` job. You'll use a regex to only use the hash
+values. Assuming your hashes are stored in
+`needs.build.outputs.[hash-$color-$flavor]`:
+
+```bash
+... | jq -r 'with_entries(select(.key | match("hash-.*-.*")))[] | @base64d' | ...
+```
+
+### A different attestation for each permutation
+
+This case is simpler. We can copy the single-attestation version's steps 1-3 and
+ignore step 4's `combine_hashes` job entirely. The changes are entirely within
+the provenance job, where we'll have to repeat the build's matrix strategy and
+use its values to define unique names for each provenance attestation using the
+[format](https://docs.github.com/en/actions/learn-github-actions/expressions#format)
+function.
+
+```yml
+  provenance:
+    needs: [build]
+    matrix:
+      color: ["red", "blue", "green"]
+      flavor: ["mint", "vanilla"]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      base64-subjects: "${{ needs.build.outputs[format('hash-{0}-{1}', matrix.color, matrix.flavor)] }}"
+      upload-assets: true # Optional: Upload to a new release
+```
+
+So, all together, this version becomes:
+
+```yml
+jobs:
+  build:
+    strategy:
+      matrix:
+        color: ["red", "blue", "green"]
+        flavor: ["mint", "vanilla"]
+    outputs:
+      hash-red-mint:      ${{ steps.hash.outputs.hash-red-mint }}
+      hash-red-vanilla:   ${{ steps.hash.outputs.hash-red-vanilla }}
+      hash-blue-mint:     ${{ steps.hash.outputs.hash-blue-mint }}
+      hash-blue-vanilla:  ${{ steps.hash.outputs.hash-blue-vanilla }}
+      hash-green-mint:    ${{ steps.hash.outputs.hash-green-mint }}
+      hash-green-vanilla: ${{ steps.hash.outputs.hash-green-vanilla }}
+    steps:
+      # all your build steps
+      - ...
+      - ...
+      - ...
+
+      - name: Generate subject
+        id: hash
+        run: |
+          echo "hash-${{ matrix.color }}-${{ matrix.flavor }}=$( \
+            sha256sum ... | base64 -w0 \
+          )" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      base64-subjects: "${{ needs.build.outputs[format('hash-{0}-{1}', matrix.color, matrix.flavor)] }}"
       upload-assets: true # Optional: Upload to a new release
 ```
 

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -36,7 +36,7 @@ project simply generates provenance as a separate step in an existing workflow.
   - [Provenance for Python](#provenance-for-python)
 - [Provenance for matrix strategy builds](#provenance-for-matrix-strategy-builds)
   - [A single provenance attestation for all artifacts](#a-single-provenance-attestation-for-all-artifacts)
-  - [A different attestation for each permutation](#a-different-attestation-for-each-permutation)
+  - [A different attestation for each iteration](#a-different-attestation-for-each-iteration)
 - [Known Issues](#known-issues)
   - [error updating to TUF remote mirror: tuf: invalid key](#error-updating-to-tuf-remote-mirror-tuf-invalid-key)
 
@@ -1021,12 +1021,11 @@ jobs:
 
 ## Provenance for matrix strategy builds
 
-If you're building with a matrix strategy, there's a bit of necessary
-boilerplate.
-
 There are a few ways to handle provenance for matrix builds. You can create a
 single provenance file describing all the artifacts from the different
 iterations or a different file for each iteration's artifact(s).
+
+Regardless of your choice, there's unfortunately a bit of necessary boilerplate.
 
 ### A single provenance attestation for all artifacts
 
@@ -1034,7 +1033,7 @@ iterations or a different file for each iteration's artifact(s).
 with its outputs and now its matrix strategy.  
   
 GitHub currently doesn't support different outputs for matrix builds. We must
-therefore declare a different hash output for each permutation. A follow-up job
+therefore declare a different hash output for each iteration. A follow-up job
 will collate all the hashes into a single string.
 
 ```yml
@@ -1067,7 +1066,7 @@ jobs:
 
 3. As with the other examples, you'll then have to generate the hashes that
 represent your build. This step is effectively identical to all the examples
-above, except each permutation must store its hash in a different output
+above, except each iteration must store its hash in a different output
 variable.
 
 ```yml
@@ -1096,7 +1095,7 @@ variable.
 ```
 
 5. The provenance job is also effectively identical to the examples above,
-except that it `needs: [combine_hashes]` instead of the `build` job.
+except that relies on `combine_hashes` instead of the `build` job.
 
 ```yml
   provenance:
@@ -1178,7 +1177,7 @@ values. Assuming your hashes are stored in
 ... | jq -r 'with_entries(select(.key | match("hash-.*-.*")))[] | @base64d' | ...
 ```
 
-### A different attestation for each permutation
+### A different attestation for each iteration
 
 This case is simpler. We can copy the single-attestation version's steps 1-3 and
 ignore step 4's `combine_hashes` job entirely. The changes are entirely within


### PR DESCRIPTION
Closes #707.

This PR adds documentation on how to adding provenance for matrix-strategy builds. It handles both the single-file and multi-file scenarios (where maintainers want a single file for all artifacts from all iterations or a different file for each iteration, respectively).

The documentation is stored within `./internal/builders/generic/README.md`, and a reference has been added to `./internal/builders/container/README.md` (this method has not been tested with the container generator, but should work there as well).