### PR TITLE
migrate deprecated set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -157,6 +157,6 @@ func main() {
 	fmt.Printf("ref:%s\n", ref)
 
 	// Output of the Action.
-	fmt.Println(fmt.Sprintf(`::set-output name=repository::%s`, repository))
-	fmt.Println(fmt.Sprintf(`::set-output name=ref::%s`, ref))
+	github.SetOutput("repository", repository)
+	github.SetOutput("ref", ref)
 }

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -266,7 +266,7 @@ jobs:
             echo "internal error"
             exit 1
           fi
-          echo "::set-output name=id::$id"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
 
       - name: Final outcome
         id: final

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -346,8 +346,8 @@ steps:
       # Output the image name and digest so we can generate provenance.
       image=$(echo "${image_and_digest}" | cut -d':' -f1)
       digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
-      echo "::set-output name=image::$image"
-      echo "::set-output name=digest::$digest"
+      echo "image=$image" >> "$GITHUB_OUTPUT"
+      echo "digest=$digest" >> "$GITHUB_OUTPUT"
 ```
 
 3. Call the generic container workflow to generate provenance by declaring the job below:
@@ -414,8 +414,8 @@ jobs:
           # Output the image name and digest so we can generate provenance.
           image=$(echo "${image_and_digest}" | cut -d':' -f1)
           digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
-          echo "::set-output name=image::$image"
-          echo "::set-output name=digest::$digest"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
   # This step calls the generic workflow to generate provenance.
   provenance:

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -921,9 +921,9 @@ steps indicated in the workflow below:
 ```yaml
 jobs:
   build:
-    name: "Build dists"    
-    runs-on: "ubuntu-latest"    
-    environment:      
+    name: "Build dists"
+    runs-on: "ubuntu-latest"
+    environment:
       name: "publish"
       outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -933,15 +933,15 @@ jobs:
 
 ```yaml
 steps:
-  - name: "Checkout repository"        
+  - name: "Checkout repository"
     uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b" # tag=v3
 
-  - name: "Setup Python"        
+  - name: "Setup Python"
     uses: "actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984" # tag=v4
-    with:  
+    with:
       python-version: "3.x"
 
-  - name: "Install dependencies"        
+  - name: "Install dependencies"
     run: python -m pip install build
 
   - name: Build using python
@@ -955,7 +955,9 @@ steps:
 - name: Generate subject
   id: hash
   run: |
-    cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+    cd dist
+    HASHES=$(sha256sum * | base64 -w0)
+    echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
 ```
 
 4. Call the generic workflow to generate provenance by declaring the job below:
@@ -975,22 +977,22 @@ All in all, it will look as the following:
 ```yaml
 jobs:
   build:
-    name: "Build dists"    
-    runs-on: "ubuntu-latest"    
-    environment:      
+    name: "Build dists"
+    runs-on: "ubuntu-latest"
+    environment:
       name: "publish"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
   steps:
-    - name: "Checkout repository"        
+    - name: "Checkout repository"
       uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b" # tag=v3
 
-    - name: "Setup Python"        
-      uses: "actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984" # tag=v4       
-      with:  
+    - name: "Setup Python"
+      uses: "actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984" # tag=v4
+      with:
         python-version: "3.x"
 
-    - name: "Install dependencies"        
+    - name: "Install dependencies"
       run: python -m pip install build
 
     - name: Build using Python
@@ -1001,7 +1003,9 @@ jobs:
     - name: Generate subject
     id: hash
     run: |
-      cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+      cd dist
+      HASHES=$(sha256sum * | base64 -w0)
+      echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
 
   provenance:
     needs: [build]


### PR DESCRIPTION
I recently migrated my pipelines to v1.4.1 and noticed there are some warnings refering to `set-output` left. I have found #1004 which makes it sounds these last references were missed during that cleanup.

In case this was not on purpose, here is a suggestion on how we could migrate to `GITHUB_OUTPUT`. 🙂 

The only reference I have left (that I could find) is: https://github.com/datosh/slsa-github-generator/blob/2c6620ba8f96507604e3e76364a19129fbf76cc2/github/set_output.go#L36
I left that in for @asraa once set-output is EOL, as stated by comment.

Signed-off-by: Fabian Kammel <fk@edgeless.systems>