### PR TITLE
fix: fix bash syntax on release tag names

### DIFF
--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -258,9 +258,9 @@ jobs:
         run: |
           set -euo pipefail
           id=""
-          if [[ -n "$RELEASE_ID_NEW_TAGS"]]; then
+          if [[ -n "$RELEASE_ID_NEW_TAGS" ]]; then
             id="$RELEASE_ID_NEW_TAGS"
-          elif [[ -n "$RELEASE_ID_TAG_NAME"]]; then
+          elif [[ -n "$RELEASE_ID_TAG_NAME" ]]; then
             id="$RELEASE_ID_TAG_NAME"
           else
             echo "internal error"


### PR DESCRIPTION
Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1310
( I hope)

I think there was a bash syntax error here
```
set -euo pipefail
  id=""
  if [[ -n "$RELEASE_ID_NEW_TAGS"]]; then
    id="$RELEASE_ID_NEW_TAGS"
  elif [[ -n "$RELEASE_ID_TAG_NAME"]]; then
    id="$RELEASE_ID_TAG_NAME"
  else
    echo "internal error"
    exit 1
  fi
  echo "::set-output name=id::$id"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    BUILDER_BINARY: slsa-generator-generic-linux-amd64
    BUILDER_DIR: internal/builders/generic
    RELEASE_ID_NEW_TAGS: 8508[3](https://github.com/slsa-framework/example-package/actions/runs/3625957411/jobs/6114562079#step:6:3)076
    RELEASE_ID_TAG_NAME: 
/home/runner/work/_temp/9ce6b8[4](https://github.com/slsa-framework/example-package/actions/runs/3625957411/jobs/6114562079#step:6:4)8-[5](https://github.com/slsa-framework/example-package/actions/runs/3625957411/jobs/6114562079#step:6:5)7ea-4dde-ada5-071781fd0dd[6](https://github.com/slsa-framework/example-package/actions/runs/3625957411/jobs/6114562079#step:6:6).sh: line 3: syntax error in conditional expression: unexpected token `;'
```

Signed-off-by: Asra Ali <asraa@google.com>