### PR TITLE
Typo: README.md

### DIFF
--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -73,7 +73,7 @@ provenance:
   if: startsWith(github.ref, 'refs/tags/')
   uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0
   with:
-    image: ${{ needs.build.outputs.tag }}
+    image: ${{ needs.build.outputs.image }}
     digest: ${{ needs.build.outputs.digest }}
     registry-username: ${{ github.actor }}
   secrets:


### PR DESCRIPTION
This matches `jobs.provenance.with` in the next example.

Signed-off-by: raghavkaul <8695110+raghavkaul@users.noreply.github.com>