### PR TITLE
fix(generic): fix bug in generic workflow to set pre-requisite job

### DIFF
--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -209,7 +209,7 @@ jobs:
       outcome: ${{ steps.final.outputs.outcome }}
       release-id: ${{ steps.release.outputs.id }}
     runs-on: ubuntu-latest
-    needs: [generator]
+    needs: [detect-env, generator]
     permissions:
       contents: write # Needed to write artifacts to a release.
     if: inputs.upload-assets == true

--- a/.github/workflows/scripts/pre-submit.e2e.go.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.go.default.sh
@@ -30,10 +30,6 @@ e2e_verify_common_all "$ATTESTATION"
 e2e_verify_predicate_subject_name "$ATTESTATION" "$BINARY"
 e2e_verify_predicate_buildType "$ATTESTATION" "https://github.com/slsa-framework/slsa-github-generator/go@v1"
 
-# Verify extra invocation environment.
-e2e_verify_predicate_invocation_environment "$ATTESTATION" "os" "ubuntu20"
-e2e_verify_predicate_invocation_environment "$ATTESTATION" "arch" "X64"
-
 # Verify the buildConfig
 
 # First step is vendoring


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1327

It seemed like the `repository` and `ref` were not set during the upload-assets job, and because of this, example-package was checked out instead of the builder repository. This was because that job did not require `detect-env` where the `repository` and `ref` come from, so they were probably resolved before that job completed.