### PR TITLE
fix: add back go presubmit verification of arch and os

### DIFF
--- a/.github/workflows/scripts/pre-submit.e2e.go.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.go.default.sh
@@ -26,6 +26,10 @@ LDFLAGS=$(e2e_this_file | cut -d '.' -f4 | grep -v noldflags)
 # Verify common provenance fields.
 e2e_verify_common_all "$ATTESTATION"
 
+# Verify Go specific environment vars are set
+e2e_verify_predicate_invocation_environment "$1" "os" "ubuntu22"
+e2e_verify_predicate_invocation_environment "$1" "arch" "X64"
+
 # Verify the subject and build type
 e2e_verify_predicate_subject_name "$ATTESTATION" "$BINARY"
 e2e_verify_predicate_buildType "$ATTESTATION" "https://github.com/slsa-framework/slsa-github-generator/go@v1"

--- a/.github/workflows/scripts/pre-submit.e2e.go.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.go.default.sh
@@ -27,8 +27,8 @@ LDFLAGS=$(e2e_this_file | cut -d '.' -f4 | grep -v noldflags)
 e2e_verify_common_all "$ATTESTATION"
 
 # Verify Go specific environment vars are set
-e2e_verify_predicate_invocation_environment "$1" "os" "ubuntu22"
-e2e_verify_predicate_invocation_environment "$1" "arch" "X64"
+e2e_verify_predicate_invocation_environment "$ATTESTATION" "os" "ubuntu22"
+e2e_verify_predicate_invocation_environment "$ATTESTATION" "arch" "X64"
 
 # Verify the subject and build type
 e2e_verify_predicate_subject_name "$ATTESTATION" "$BINARY"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Adds back the go presubmit verification of arch and os, updating the arch to ubuntu22 

See commit here:
https://github.com/slsa-framework/slsa-github-generator/commit/9faebcac31ac83ab693adf4e0dfe0d46c70c81cf

@ianlewis should we entirely remove these? @laurentsimon pointed out it's captured in materials: https://github.com/slsa-framework/slsa-github-generator/blob/9faebcac31ac83ab693adf4e0dfe0d46c70c81cf/internal/builders/go/pkg/provenance.go#L159
If so, I can update this PR to remove those and replace these checks with the runner material check.