### PR TITLE
refactor: enable and fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,8 +30,7 @@ linters:
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable errorlint
     # - errorlint
     - exhaustive
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable exportloopref
-    # - exportloopref
+    - exportloopref
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable gci
     # - gci
     - gochecknoinits

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     # Some linters have been removed because of the go 1.18 issues.
     # https://github.com/golangci/golangci-lint/issues/2649
     - asciicheck
-    - deadcode
     - depguard
     - dogsled
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable errcheck
@@ -79,7 +78,6 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable thelper
     # - wrapcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,11 @@ run:
   deadline: 5m
 issues:
   # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): revive `package-comments` and `exported` rules.
-  # include:
-  #   - EXC0012
-  #   - EXC0013
-  #   - EXC0014
-  #   - EXC0015
+  include:
+    - EXC0012
+    - EXC0013
+    - EXC0014
+  # - EXC0015
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,8 +37,7 @@ linters:
     - gochecknoinits
     - gocognit
     - goconst
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable gocritic
-    # - gocritic
+    - gocritic
     - gocyclo
     - godot
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable godox

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,8 +26,7 @@ linters:
     - asciicheck
     - depguard
     - dogsled
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable errcheck
-    # - errcheck
+    - errcheck
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable errorlint
     # - errorlint
     - exhaustive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,8 +53,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable lll
-    # - lll
+    - lll
     - makezero
     - misspell
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,8 +51,7 @@ linters:
     - goprintffuncname
     - gosec
     - gosimple
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable govet
-    # - govet
+    - govet
     - ineffassign
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable lll
     # - lll

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,8 +49,7 @@ linters:
     - goimports
     - gomodguard
     - goprintffuncname
-    # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable gosec
-    # - gosec
+    - gosec
     - gosimple
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable govet
     # - govet

--- a/github/oidc.go
+++ b/github/oidc.go
@@ -42,12 +42,6 @@ type OIDCToken struct {
 	// Issuer is the token issuer.
 	Issuer string
 
-	// Audience is the audience for which the token was granted.
-	Audience []string
-
-	// Expiry is the expiration date of the token.
-	Expiry time.Time
-
 	// JobWorkflowRef is a reference to the current job workflow.
 	JobWorkflowRef string `json:"job_workflow_ref"`
 
@@ -59,6 +53,12 @@ type OIDCToken struct {
 
 	// ActorID is the unique ID of the actor who triggered the build.
 	ActorID string `json:"actor_id"`
+
+	// Expiry is the expiration date of the token.
+	Expiry time.Time
+
+	// Audience is the audience for which the token was granted.
+	Audience []string
 }
 
 // errURLError indicates the OIDC server URL is invalid.
@@ -91,12 +91,12 @@ type OIDCClient struct {
 	// requestURL is the GitHub URL to request a OIDC token.
 	requestURL *url.URL
 
-	// bearerToken is used to request an ID token.
-	bearerToken string
-
 	// verifierFunc is a factory to generate an oidc.IDTokenVerifier for token verification.
 	// This is used for tests.
 	verifierFunc func(context.Context) (*oidc.IDTokenVerifier, error)
+
+	// bearerToken is used to request an ID token.
+	bearerToken string
 }
 
 // NewOIDCClient returns new GitHub OIDC provider client.

--- a/github/oidc.go
+++ b/github/oidc.go
@@ -104,7 +104,11 @@ func NewOIDCClient() (*OIDCClient, error) {
 	requestURL := os.Getenv(requestURLEnvKey)
 	parsedURL, err := url.ParseRequestURI(requestURL)
 	if err != nil {
-		return nil, errors.Errorf(&errURLError{}, "invalid request URL %q: %w; does your workflow have `id-token: write` scope?", requestURL, err)
+		return nil, errors.Errorf(
+			&errURLError{},
+			"invalid request URL %q: %w; does your workflow have `id-token: write` scope?",
+			requestURL, err,
+		)
 	}
 
 	c := OIDCClient{

--- a/github/oidc_test.go
+++ b/github/oidc_test.go
@@ -3,13 +3,14 @@ package github
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/slsa-framework/slsa-github-generator/internal/errors"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/github/oidc_test.go
+++ b/github/oidc_test.go
@@ -70,12 +70,12 @@ func TestToken(t *testing.T) {
 	now := time.Date(2022, 4, 14, 12, 24, 0, 0, time.UTC)
 
 	testCases := []struct {
-		name     string
-		audience []string
-		token    *OIDCToken
-		status   int
-		raw      string
-		err      error
+		name     string     // 16
+		raw      string     // 16
+		err      error      // 16
+		token    *OIDCToken // 8
+		audience []string   // 24
+		status   int        // 8
 	}{
 		{
 			name:     "basic token",

--- a/github/oidctest.go
+++ b/github/oidctest.go
@@ -20,12 +20,12 @@ import (
 
 type jsonToken struct {
 	Issuer            string   `json:"iss"`
-	Audience          []string `json:"aud"`
-	Expiry            int64    `json:"exp"`
 	JobWorkflowRef    string   `json:"job_workflow_ref"`
 	RepositoryID      string   `json:"repository_id"`
 	RepositoryOwnerID string   `json:"repository_owner_id"`
 	ActorID           string   `json:"actor_id"`
+	Audience          []string `json:"aud"`
+	Expiry            int64    `json:"exp"`
 }
 
 // testKeySet is an oidc.KeySet that can be used in tests.

--- a/github/workflow.go
+++ b/github/workflow.go
@@ -49,7 +49,7 @@ type WorkflowContext struct {
 }
 
 // RepositoryURI returns a full repository URI for the repo that triggered the workflow.
-func (c WorkflowContext) RepositoryURI() string {
+func (c *WorkflowContext) RepositoryURI() string {
 	if c.ServerURL == "" || c.Repository == "" {
 		return ""
 	}

--- a/internal/builders/container/generate.go
+++ b/internal/builders/container/generate.go
@@ -45,27 +45,23 @@ that it is being run in the context of a Github Actions workflow.`,
 
 			b := common.GenericBuild{
 				// NOTE: Subjects are nil because we are only writing the predicate.
-				GithubActionsBuild: slsa.NewGithubActionsBuild(nil, ghContext),
+				GithubActionsBuild: slsa.NewGithubActionsBuild(nil, &ghContext),
 				BuildTypeURI:       containerBuildType,
 			}
 
 			if provider != nil {
 				b.WithClients(provider)
-			} else {
+			} else if utils.IsPresubmitTests() {
 				// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-				if utils.IsPresubmitTests() {
-					b.WithClients(&slsa.NilClientProvider{})
-				}
+				b.WithClients(&slsa.NilClientProvider{})
 			}
 
 			g := slsa.NewHostedActionsGenerator(&b)
 			if provider != nil {
 				g.WithClients(provider)
-			} else {
+			} else if utils.IsPresubmitTests() {
 				// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-				if utils.IsPresubmitTests() {
-					g.WithClients(&slsa.NilClientProvider{})
-				}
+				g.WithClients(&slsa.NilClientProvider{})
 			}
 
 			p, err := g.Generate(ctx)

--- a/internal/builders/container/generate.go
+++ b/internal/builders/container/generate.go
@@ -78,7 +78,11 @@ that it is being run in the context of a Github Actions workflow.`,
 		},
 	}
 
-	c.Flags().StringVarP(&predicatePath, "predicate", "p", "predicate.json", "Path to write the unsigned provenance predicate.")
+	c.Flags().StringVarP(
+		&predicatePath,
+		"predicate", "p", "predicate.json",
+		"Path to write the unsigned provenance predicate.",
+	)
 
 	return c
 }

--- a/internal/builders/container/generate_test.go
+++ b/internal/builders/container/generate_test.go
@@ -49,7 +49,12 @@ func Test_generateCmd_default_predicate(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := generateCmd(&slsa.NilClientProvider{}, checkTest(t))
 	c.SetOut(new(bytes.Buffer))
@@ -79,7 +84,12 @@ func Test_generateCmd_custom_predicate(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := generateCmd(&slsa.NilClientProvider{}, checkTest(t))
 	c.SetOut(new(bytes.Buffer))
@@ -110,7 +120,12 @@ func Test_generateCmd_invalid_path(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	// A custom check function that checks the error type is the expected error type.
 	check := func(err error) {

--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -75,26 +75,22 @@ run in the context of a Github Actions workflow.`,
 			ctx := context.Background()
 
 			b := common.GenericBuild{
-				GithubActionsBuild: slsa.NewGithubActionsBuild(parsedSubjects, ghContext),
+				GithubActionsBuild: slsa.NewGithubActionsBuild(parsedSubjects, &ghContext),
 				BuildTypeURI:       provenanceOnlyBuildType,
 			}
 			if provider != nil {
 				b.WithClients(provider)
-			} else {
+			} else if utils.IsPresubmitTests() {
 				// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-				if utils.IsPresubmitTests() {
-					b.WithClients(&slsa.NilClientProvider{})
-				}
+				b.WithClients(&slsa.NilClientProvider{})
 			}
 
 			g := slsa.NewHostedActionsGenerator(&b)
 			if provider != nil {
 				g.WithClients(provider)
-			} else {
+			} else if utils.IsPresubmitTests() {
 				// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-				if utils.IsPresubmitTests() {
-					g.WithClients(&slsa.NilClientProvider{})
-				}
+				g.WithClients(&slsa.NilClientProvider{})
 			}
 
 			p, err := g.Generate(ctx)

--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -34,7 +34,9 @@ import (
 )
 
 // attestCmd returns the 'attest' command.
-func attestCmd(provider slsa.ClientProvider, check func(error), signer signing.Signer, tlog signing.TransparencyLog) *cobra.Command {
+func attestCmd(provider slsa.ClientProvider, check func(error),
+	signer signing.Signer, tlog signing.TransparencyLog,
+) *cobra.Command {
 	var attPath string
 	var subjects string
 
@@ -128,8 +130,14 @@ run in the context of a Github Actions workflow.`,
 		},
 	}
 
-	c.Flags().StringVarP(&attPath, "signature", "g", "", "Path to write the signed provenance.")
-	c.Flags().StringVarP(&subjects, "subjects", "s", "", "Formatted list of subjects in the same format as sha256sum (base64 encoded).")
+	c.Flags().StringVarP(
+		&attPath, "signature", "g", "",
+		"Path to write the signed provenance.",
+	)
+	c.Flags().StringVarP(
+		&subjects, "subjects", "s", "",
+		"Formatted list of subjects in the same format as sha256sum (base64 encoded).",
+	)
 
 	return c
 }

--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -125,8 +125,10 @@ run in the context of a Github Actions workflow.`,
 			check(err)
 
 			// Print the provenance name and sha256 so it can be used by the workflow.
-			github.SetOutput("provenance-name", attPath)
-			github.SetOutput("provenance-sha256", fmt.Sprintf("%x", sha256.Sum256(attBytes)))
+			err = github.SetOutput("provenance-name", attPath)
+			check(err)
+			err = github.SetOutput("provenance-sha256", fmt.Sprintf("%x", sha256.Sum256(attBytes)))
+			check(err)
 		},
 	}
 

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -170,7 +170,12 @@ func Test_attestCmd_default_single_artifact(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
@@ -203,7 +208,12 @@ func Test_attestCmd_default_multi_artifact(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
@@ -238,7 +248,12 @@ func Test_attestCmd_custom_provenance_name(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
@@ -272,7 +287,12 @@ func Test_attestCmd_invalid_extension(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	// A custom check function that checks the error type is the expected error type.
 	check := func(err error) {
@@ -316,7 +336,9 @@ func Test_attestCmd_invalid_path(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err = os.Chdir(currentDir)
+	}()
 
 	// A custom check function that checks the error type is the expected error type.
 	check := func(err error) {
@@ -362,7 +384,12 @@ func Test_attestCmd_subdirectory_artifact(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	defer os.Chdir(currentDir)
+	defer func() {
+		err := os.Chdir(currentDir)
+		if err != nil {
+			t.Errorf("unexpected failure: %v", err)
+		}
+	}()
 
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -23,8 +23,8 @@ func TestParseSubjects(t *testing.T) {
 	testCases := []struct {
 		name     string
 		str      string
-		expected []intoto.Subject
 		err      error
+		expected []intoto.Subject
 	}{
 		{
 			name: "single",

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/slsa-framework/slsa-github-generator/slsa"
 )
 
+const (
+	testHash = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  artifact1"
+)
+
 // TestParseSubjects tests the parseSubjects function.
 func TestParseSubjects(t *testing.T) {
 	testCases := []struct {
@@ -54,8 +58,10 @@ func TestParseSubjects(t *testing.T) {
 		},
 		{
 			name: "extra whitespace",
-			// echo -e "\t  2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 \t hoge fuga  \t  " | base64 -w0
-			str: "CSAgMmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiAJIGhvZ2UgZnVnYSAgCSAgCg==",
+			// echo -e "\t  2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 \
+			// \t hoge fuga  \t  " | base64 -w0
+			str: "CSAgMmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3Y" +
+				"mFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiAJIGhvZ2UgZnVnYSAgCSAgCg==",
 			expected: []intoto.Subject{
 				{
 					Name: "hoge fuga",
@@ -68,8 +74,10 @@ func TestParseSubjects(t *testing.T) {
 
 		{
 			name: "multiple",
-			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 hoge\ne712aff3705ac314b9a890e0ec208faa20054eee514d86ab913d768f94e01279 fuga" | base64 -w0
-			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dlCmU3MTJhZmYzNzA1YWMzMTRiOWE4OTBlMGVjMjA4ZmFhMjAwNTRlZWU1MTRkODZhYjkxM2Q3NjhmOTRlMDEyNzkgZnVnYQo=",
+			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 \
+			// hoge\ne712aff3705ac314b9a890e0ec208faa20054eee514d86ab913d768f94e01279 fuga" | base64 -w0
+			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dlCmU" +
+				"3MTJhZmYzNzA1YWMzMTRiOWE4OTBlMGVjMjA4ZmFhMjAwNTRlZWU1MTRkODZhYjkxM2Q3NjhmOTRlMDEyNzkgZnVnYQo=",
 			expected: []intoto.Subject{
 				{
 					Name: "hoge",
@@ -92,8 +100,10 @@ func TestParseSubjects(t *testing.T) {
 		},
 		{
 			name: "blank lines",
-			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 hoge\n\ne712aff3705ac314b9a890e0ec208faa20054eee514d86ab913d768f94e01279 fuga" | base64 -w0
-			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dlCgplNzEyYWZmMzcwNWFjMzE0YjlhODkwZTBlYzIwOGZhYTIwMDU0ZWVlNTE0ZDg2YWI5MTNkNzY4Zjk0ZTAxMjc5IGZ1Z2EK",
+			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 \
+			// hoge\n\ne712aff3705ac314b9a890e0ec208faa20054eee514d86ab913d768f94e01279 fuga" | base64 -w0
+			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dlCgp" +
+				"lNzEyYWZmMzcwNWFjMzE0YjlhODkwZTBlYzIwOGZhYTIwMDU0ZWVlNTE0ZDg2YWI5MTNkNzY4Zjk0ZTAxMjc5IGZ1Z2EK",
 			expected: []intoto.Subject{
 				{
 					Name: "hoge",
@@ -123,8 +133,10 @@ func TestParseSubjects(t *testing.T) {
 		},
 		{
 			name: "duplicate name",
-			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 hoge\n2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 hoge" | base64 -w0
-			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dlCjJlMDM5MGViMDI0YTUyOTYzZGI3Yjk1ZTg0YTljMmIxMmMwMDQwNTRhN2JhZDlhOTdlYzBjN2M4OWQ0NjgxZDIgaG9nZQo=",
+			// echo -e "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 \
+			// hoge\n2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2 hoge" | base64 -w0
+			str: "MmUwMzkwZWIwMjRhNTI5NjNkYjdiOTVlODRhOWMyYjEyYzAwNDA1NGE3YmFkOWE5N2VjMGM3Yzg5ZDQ2ODFkMiBob2dl" +
+				"CjJlMDM5MGViMDI0YTUyOTYzZGI3Yjk1ZTg0YTljMmIxMmMwMDQwNTRhN2JhZDlhOTdlYzBjN2M4OWQ0NjgxZDIgaG9nZQo=",
 			err: &errDuplicateSubject{},
 		},
 		{
@@ -180,7 +192,7 @@ func Test_attestCmd_default_single_artifact(t *testing.T) {
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
 	c.SetArgs([]string{
-		"--subjects", base64.StdEncoding.EncodeToString([]byte("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  artifact1")),
+		"--subjects", base64.StdEncoding.EncodeToString([]byte(testHash)),
 	})
 	if err := c.Execute(); err != nil {
 		t.Errorf("unexpected failure: %v", err)
@@ -258,7 +270,7 @@ func Test_attestCmd_custom_provenance_name(t *testing.T) {
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
 	c.SetArgs([]string{
-		"--subjects", base64.StdEncoding.EncodeToString([]byte("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  artifact1")),
+		"--subjects", base64.StdEncoding.EncodeToString([]byte(testHash)),
 		"--signature", "custom.intoto.jsonl",
 	})
 	if err := c.Execute(); err != nil {
@@ -309,7 +321,7 @@ func Test_attestCmd_invalid_extension(t *testing.T) {
 	c := attestCmd(&slsa.NilClientProvider{}, check, &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
 	c.SetArgs([]string{
-		"--subjects", base64.StdEncoding.EncodeToString([]byte("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  artifact1")),
+		"--subjects", base64.StdEncoding.EncodeToString([]byte(testHash)),
 		"--signature", "invalid_name",
 	})
 	if err := c.Execute(); err != nil {
@@ -355,7 +367,7 @@ func Test_attestCmd_invalid_path(t *testing.T) {
 	c := attestCmd(&slsa.NilClientProvider{}, check, &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
 	c.SetArgs([]string{
-		"--subjects", base64.StdEncoding.EncodeToString([]byte("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  artifact1")),
+		"--subjects", base64.StdEncoding.EncodeToString([]byte(testHash)),
 		"--signature", "/provenance.intoto.jsonl",
 	})
 	if err := c.Execute(); err != nil {
@@ -394,7 +406,7 @@ func Test_attestCmd_subdirectory_artifact(t *testing.T) {
 	c := attestCmd(&slsa.NilClientProvider{}, checkTest(t), &testutil.TestSigner{}, &testutil.TestTransparencyLog{})
 	c.SetOut(new(bytes.Buffer))
 	c.SetArgs([]string{
-		"--subjects", base64.StdEncoding.EncodeToString([]byte("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  test/artifact1")),
+		"--subjects", base64.StdEncoding.EncodeToString([]byte(testHash)),
 	})
 	if err := c.Execute(); err != nil {
 		t.Errorf("unexpected failure: %v", err)

--- a/internal/builders/go/main.go
+++ b/internal/builders/go/main.go
@@ -94,14 +94,20 @@ func runProvenanceGeneration(subject, digest, commands, envs, workingDir, rekor 
 		return err
 	}
 
-	github.SetOutput("signed-provenance-name", filename)
+	err = github.SetOutput("signed-provenance-name", filename)
+	if err != nil {
+		return err
+	}
 
 	h, err := computeSHA256(filename)
 	if err != nil {
 		return err
 	}
 
-	github.SetOutput("signed-provenance-sha256", h)
+	err = github.SetOutput("signed-provenance-sha256", h)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -295,7 +295,10 @@ func Test_runBuild(t *testing.T) {
 				return
 			}
 
-			file.Seek(0, 0)
+			ret, err := file.Seek(0, 0)
+			if ret != 0 || err != nil {
+				t.Errorf("seek to zero")
+			}
 			cmd, env, subject, wd, err := extract(file)
 			if err != nil {
 				t.Errorf("extract: %v", err)

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -48,10 +48,10 @@ func Test_runBuild(t *testing.T) {
 		name       string
 		config     string
 		evalEnvs   string
+		workingDir string
 		err        error
 		commands   []string
 		envs       []string
-		workingDir string
 	}{
 		{
 			name:     "two ldflags",

--- a/internal/builders/go/pkg/build.go
+++ b/internal/builders/go/pkg/build.go
@@ -237,7 +237,8 @@ func (b *GoBuild) getDir() (string, error) {
 }
 
 func (b *GoBuild) generateCommand(flags []string, binary string) []string {
-	command := append(flags, []string{"-o", binary}...)
+	command := flags
+	command = append(command, "-o", binary)
 
 	// Add the entry point.
 	if b.cfg.Main != nil {

--- a/internal/builders/go/pkg/build.go
+++ b/internal/builders/go/pkg/build.go
@@ -59,9 +59,9 @@ var allowedEnvVariablePrefix = map[string]bool{
 // GoBuild implements building a Go application.
 type GoBuild struct {
 	cfg *GoReleaserConfig
-	goc string
 	// Note: static env variables are contained in cfg.Env.
 	argEnv map[string]string
+	goc    string
 }
 
 // GoBuildNew returns a new GoBuild.

--- a/internal/builders/go/pkg/build.go
+++ b/internal/builders/go/pkg/build.go
@@ -153,17 +153,25 @@ func (b *GoBuild) Run(dry bool) error {
 		}
 
 		// Share the resolved name of the binary.
-		github.SetOutput("go-binary-name", filename)
+		err = github.SetOutput("go-binary-name", filename)
+		if err != nil {
+			return err
+		}
 
 		// Share the command used.
-		github.SetOutput("go-command", command)
+		err = github.SetOutput("go-command", command)
+		if err != nil {
+			return err
+		}
 
 		// Share the env variables used.
-		github.SetOutput("go-env", menv)
+		err = github.SetOutput("go-env", menv)
+		if err != nil {
+			return err
+		}
 
 		// Share working directory necessary for issuing the vendoring command.
-		github.SetOutput("go-working-dir", dir)
-		return nil
+		return github.SetOutput("go-working-dir", dir)
 	}
 
 	binary, err := getOutputBinaryPath(os.Getenv("OUTPUT_BINARY"))

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -794,7 +794,8 @@ func Test_generateLdflags(t *testing.T) {
 				"start-{{ .Env.VAR3 }}-name-{{ .Env.VAR1 }}-end",
 				"start-{{ .Env.VAR3 }}-name-{{ .Env.VAR2 }}-end",
 			},
-			outldflags: "start-value1-name-value2-end start-value1-name-value3-end start-value3-name-value1-end start-value3-name-value2-end",
+			outldflags: "start-value1-name-value2-end start-value1-name-value3-end" +
+				"start-value3-name-value1-end start-value3-name-value2-end",
 		},
 		{
 			name:   "several ldflags and tag",
@@ -808,7 +809,8 @@ func Test_generateLdflags(t *testing.T) {
 				"{{ .Env.VAR3 }}-name-{{ .Env.VAR1 }}-{{ .Tag }}-{{ .Tag }}",
 				"{{ .Env.VAR3 }}-name-{{ .Env.VAR2 }}-{{ .Tag }}-end",
 			},
-			outldflags: "start-value1-name-value2-v1.2.3-end value1-name-value3 value3-name-value1-v1.2.3-v1.2.3 value3-name-value2-v1.2.3-end",
+			outldflags: "start-value1-name-value2-v1.2.3-end value1-name-value3" +
+				"value3-name-value1-v1.2.3-v1.2.3 value3-name-value2-v1.2.3-end",
 		},
 		{
 			name:   "several ldflags and Arch and Os",

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -1003,7 +1003,8 @@ func Test_generateCommand(t *testing.T) {
 				},
 			}
 
-			for _, cfg := range cfgs {
+			for i := range cfgs {
+				cfg := cfgs[i]
 				c, err := fromConfig(&cfg)
 				if err != nil {
 					t.Errorf("fromConfig: %v", err)

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -70,9 +70,9 @@ func Test_getOutputBinaryPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		expected error
 		name     string
 		path     string
-		expected error
 	}{
 		{
 			name:     "empty output",
@@ -465,52 +465,52 @@ func Test_SetArgEnvVariables(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		argEnv   string
 		expected struct {
-			err error
 			env map[string]string
+			err error
 		}
+		name   string
+		argEnv string
 	}{
 		{
 			name:   "valid arg envs",
 			argEnv: "VAR1:value1, VAR2:value2",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
-				err: nil,
 				env: map[string]string{"VAR1": "value1", "VAR2": "value2"},
+				err: nil,
 			},
 		},
 		{
 			name:   "empty arg envs",
 			argEnv: "",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
-				err: nil,
 				env: map[string]string{},
+				err: nil,
 			},
 		},
 		{
 			name:   "valid arg envs not space",
 			argEnv: "VAR1:value1,VAR2:value2",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
-				err: nil,
 				env: map[string]string{"VAR1": "value1", "VAR2": "value2"},
+				err: nil,
 			},
 		},
 		{
 			name:   "invalid arg empty 2 values",
 			argEnv: "VAR1:value1,",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
 				err: errorInvalidEnvArgument,
 			},
@@ -519,8 +519,8 @@ func Test_SetArgEnvVariables(t *testing.T) {
 			name:   "invalid arg empty 3 values",
 			argEnv: "VAR1:value1,, VAR3:value3",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
 				err: errorInvalidEnvArgument,
 			},
@@ -529,8 +529,8 @@ func Test_SetArgEnvVariables(t *testing.T) {
 			name:   "invalid arg uses equal",
 			argEnv: "VAR1=value1",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
 				err: errorInvalidEnvArgument,
 			},
@@ -539,19 +539,19 @@ func Test_SetArgEnvVariables(t *testing.T) {
 			name:   "valid single arg",
 			argEnv: "VAR1:value1",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
-				err: nil,
 				env: map[string]string{"VAR1": "value1"},
+				err: nil,
 			},
 		},
 		{
 			name:   "invalid valid single arg with empty",
 			argEnv: "VAR1:value1:",
 			expected: struct {
-				err error
 				env map[string]string
+				err error
 			}{
 				err: errorInvalidEnvArgument,
 			},
@@ -707,12 +707,12 @@ func Test_generateLdflags(t *testing.T) {
 	// t.Parallel()
 
 	tests := []struct {
+		githubEnv  map[string]string
 		name       string
 		argEnv     string
-		inldflags  []string
-		githubEnv  map[string]string
-		err        error
 		outldflags string
+		err        error
+		inldflags  []string
 	}{
 		{
 			name:       "version ldflags",
@@ -879,8 +879,8 @@ func Test_generateFlags(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		flags    []string
 		expected error
+		flags    []string
 	}{
 		{
 			name:     "valid flags",
@@ -1034,18 +1034,18 @@ func asPointer(s string) *string {
 func TestGoBuild_Run(t *testing.T) {
 	type fields struct {
 		cfg    *GoReleaserConfig
-		goc    string
 		argEnv map[string]string
+		goc    string
 	}
 	type args struct {
 		dry bool
 	}
 	tests := []struct {
 		name    string
+		err     error
 		fields  fields
 		args    args
 		wantErr bool
-		err     error
 	}{
 		{
 			name: "dry run valid flags",

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -113,48 +113,28 @@ func Test_getOutputBinaryPath(t *testing.T) {
 func Test_isAllowedArg(t *testing.T) {
 	t.Parallel()
 
-	var tests []struct {
+	type test struct {
 		name     string
 		argument string
 		expected bool
 	}
 
+	var tests []test
+
 	for k := range allowedBuildArgs {
-		tests = append(tests, struct {
-			name     string
-			argument string
-			expected bool
-		}{
+		tests = append(tests, test{
 			name:     fmt.Sprintf("%s argument", k),
 			argument: k,
 			expected: true,
-		})
-
-		tests = append(tests, struct {
-			name     string
-			argument string
-			expected bool
-		}{
+		}, test{
 			name:     fmt.Sprintf("%sbla argument", k),
 			argument: fmt.Sprintf("%sbla", k),
 			expected: true,
-		})
-
-		tests = append(tests, struct {
-			name     string
-			argument string
-			expected bool
-		}{
+		}, test{
 			name:     fmt.Sprintf("bla %s argument", k),
 			argument: fmt.Sprintf("bla%s", k),
 			expected: false,
-		})
-
-		tests = append(tests, struct {
-			name     string
-			argument string
-			expected bool
-		}{
+		}, test{
 			name:     fmt.Sprintf("space %s argument", k),
 			argument: fmt.Sprintf(" %s", k),
 			expected: false,
@@ -1031,7 +1011,8 @@ func Test_generateCommand(t *testing.T) {
 				b := GoBuildNew("gocompiler", c)
 
 				command := b.generateCommand(tt.flags, "out-binary")
-				expectedCommand := append(tt.flags, "-o", "out-binary")
+				expectedCommand := tt.flags
+				expectedCommand = append(expectedCommand, "-o", "out-binary")
 				if cfg.Main != nil {
 					expectedCommand = append(expectedCommand, *cfg.Main)
 				}

--- a/internal/builders/go/pkg/config.go
+++ b/internal/builders/go/pkg/config.go
@@ -40,27 +40,27 @@ var supportedVersions = map[int]bool{
 }
 
 type goReleaserConfigFile struct {
+	Main    *string  `yaml:"main"`
+	Dir     *string  `yaml:"dir"`
 	Goos    string   `yaml:"goos"`
 	Goarch  string   `yaml:"goarch"`
+	Binary  string   `yaml:"binary"`
 	Env     []string `yaml:"env"`
 	Flags   []string `yaml:"flags"`
 	Ldflags []string `yaml:"ldflags"`
-	Binary  string   `yaml:"binary"`
 	Version int      `yaml:"version"`
-	Main    *string  `yaml:"main"`
-	Dir     *string  `yaml:"dir"`
 }
 
 // GoReleaserConfig tracks configuration for goreleaser.
 type GoReleaserConfig struct {
-	Goos    string
-	Goarch  string
+	Env     map[string]string
 	Main    *string
 	Dir     *string
-	Env     map[string]string
+	Goos    string
+	Goarch  string
+	Binary  string
 	Flags   []string
 	Ldflags []string
-	Binary  string
 }
 
 func configFromString(b []byte) (*GoReleaserConfig, error) {

--- a/internal/builders/go/pkg/config.go
+++ b/internal/builders/go/pkg/config.go
@@ -51,6 +51,7 @@ type goReleaserConfigFile struct {
 	Dir     *string  `yaml:"dir"`
 }
 
+// GoReleaserConfig tracks configuration for goreleaser.
 type GoReleaserConfig struct {
 	Goos    string
 	Goarch  string
@@ -71,12 +72,14 @@ func configFromString(b []byte) (*GoReleaserConfig, error) {
 	return fromConfig(&cf)
 }
 
-func ConfigFromFile(pathfn string) (*GoReleaserConfig, error) {
-	if err := validatePath(pathfn); err != nil {
+// ConfigFromFile reads the file located at path and builds a GoReleaserConfig
+// from it.
+func ConfigFromFile(path string) (*GoReleaserConfig, error) {
+	if err := validatePath(path); err != nil {
 		return nil, err
 	}
 
-	cfg, err := os.ReadFile(filepath.Clean(pathfn))
+	cfg, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("os.ReadFile: %w", err)
 	}

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -36,13 +36,13 @@ const (
 
 type (
 	step struct {
+		WorkingDir string   `json:"workingDir"`
 		Command    []string `json:"command"`
 		Env        []string `json:"env"`
-		WorkingDir string   `json:"workingDir"`
 	}
 	buildConfig struct {
-		Version int    `json:"version"`
 		Steps   []step `json:"steps"`
+		Version int    `json:"version"`
 	}
 )
 

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -97,7 +97,7 @@ func GenerateProvenance(name, digest, command, envs, workingDir string, s signin
 					"sha256": digest,
 				},
 			},
-		}, gh),
+		}, &gh),
 		buildConfig: buildConfig{
 			Version: buildConfigVersion,
 			Steps: []step{
@@ -123,11 +123,9 @@ func GenerateProvenance(name, digest, command, envs, workingDir string, s signin
 	// Pre-submit tests don't have access to write OIDC token.
 	if provider != nil {
 		b.WithClients(provider)
-	} else {
+	} else if utils.IsPresubmitTests() {
 		// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-		if utils.IsPresubmitTests() {
-			b.GithubActionsBuild.WithClients(&slsa.NilClientProvider{})
-		}
+		b.GithubActionsBuild.WithClients(&slsa.NilClientProvider{})
 	}
 
 	ctx := context.Background()
@@ -135,11 +133,9 @@ func GenerateProvenance(name, digest, command, envs, workingDir string, s signin
 	// Pre-submit tests don't have access to write OIDC token.
 	if provider != nil {
 		g.WithClients(provider)
-	} else {
+	} else if utils.IsPresubmitTests() {
 		// TODO(github.com/slsa-framework/slsa-github-generator/issues/124): Remove
-		if utils.IsPresubmitTests() {
-			g.WithClients(&slsa.NilClientProvider{})
-		}
+		g.WithClients(&slsa.NilClientProvider{})
 	}
 	p, err := g.Generate(ctx)
 	if err != nil {

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -64,7 +64,9 @@ func (b *goProvenanceBuild) BuildConfig(context.Context) (interface{}, error) {
 // GenerateProvenance translates github context into a SLSA provenance
 // attestation.
 // Spec: https://slsa.dev/provenance/v0.2
-func GenerateProvenance(name, digest, command, envs, workingDir string, s signing.Signer, r signing.TransparencyLog, provider slsa.ClientProvider) ([]byte, error) {
+func GenerateProvenance(name, digest, command, envs, workingDir string,
+	s signing.Signer, r signing.TransparencyLog, provider slsa.ClientProvider,
+) ([]byte, error) {
 	gh, err := github.GetWorkflowContext()
 	if err != nil {
 		return nil, err
@@ -158,7 +160,10 @@ func GenerateProvenance(name, digest, command, envs, workingDir string, s signin
 	// Add details about the runner's OS to the materials
 	runnerMaterials := slsacommon.ProvenanceMaterial{
 		// TODO: capture the digest here too
-		URI: fmt.Sprintf("https://github.com/actions/virtual-environments/releases/tag/%s/%s", os.Getenv("ImageOS"), os.Getenv("ImageVersion")),
+		URI: fmt.Sprintf(
+			"https://github.com/actions/virtual-environments/releases/tag/%s/%s",
+			os.Getenv("ImageOS"), os.Getenv("ImageVersion"),
+		),
 	}
 	p.Predicate.Materials = append(p.Predicate.Materials, runnerMaterials)
 

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -152,7 +152,10 @@ func GenerateProvenance(name, digest, command, envs, workingDir string, s signin
 	//
 	// NOTE: map is a reference so modifying invEnv modifies
 	// p.Predicate.Invocation.Environment.
-	invEnv := p.Predicate.Invocation.Environment.(map[string]interface{})
+	invEnv, ok := p.Predicate.Invocation.Environment.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("converting %T to map[string]interface{}", p.Predicate.Invocation.Environment)
+	}
 	invEnv["arch"] = os.Getenv("RUNNER_ARCH")
 	invEnv["os"] = os.Getenv("ImageOS")
 

--- a/internal/builders/go/pkg/provenance_test.go
+++ b/internal/builders/go/pkg/provenance_test.go
@@ -27,7 +27,11 @@ func TestGenerateProvenance_withErr(t *testing.T) {
 	t.Setenv("GITHUB_EVENT_NAME", "non_event")
 	t.Setenv("GITHUB_CONTEXT", "{}")
 	sha256 := "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2"
-	_, err := GenerateProvenance("foo", sha256, "", "", "/home/foo", &testutil.TestSigner{}, &testutil.TransparencyLogWithErr{}, &slsa.NilClientProvider{})
+	_, err := GenerateProvenance(
+		"foo", sha256, "", "", "/home/foo",
+		&testutil.TestSigner{}, &testutil.TransparencyLogWithErr{},
+		&slsa.NilClientProvider{},
+	)
 	if want, got := testutil.ErrTransparencyLog, err; want != got {
 		t.Errorf("expected error, want: %v, got: %v", want, got)
 	}

--- a/internal/builders/nodejs/attest.go
+++ b/internal/builders/nodejs/attest.go
@@ -22,7 +22,9 @@ import (
 )
 
 // attestCmd runs the 'attest' command.
-func attestCmd(provider slsa.ClientProvider, check func(error), signer signing.Signer, tlog signing.TransparencyLog) *cobra.Command {
+func attestCmd(provider slsa.ClientProvider, check func(error),
+	signer signing.Signer, tlog signing.TransparencyLog,
+) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "attest",
 		Short: "Run attest command",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -25,29 +25,29 @@ import (
 
 // CommandRunner runs commands and returns the build steps that were run.
 type CommandRunner struct {
-	// Env is global environment variables passed to all commands.
-	Env []string
-
-	// Steps are the steps to execute.
-	Steps []*CommandStep
-
 	// Stdout is the Writer used for Stdout. If nil then os.Stdout is used.
 	Stdout io.Writer
 
 	// Stderr is the Writer used for Stderr. If nil then os.Stderr is used.
 	Stderr io.Writer
+
+	// Env is global environment variables passed to all commands.
+	Env []string
+
+	// Steps are the steps to execute.
+	Steps []*CommandStep
 }
 
 // CommandStep is a command that was executed by the builder.
 type CommandStep struct {
+	// WorkingDir is the working directory the command was executed in.
+	WorkingDir string `json:"workingDir"`
+
 	// Command is the command that was run.
 	Command []string `json:"command"`
 
 	// Env are the environment variables passed to the command.
 	Env []string `json:"env"`
-
-	// WorkingDir is the working directory the command was executed in.
-	WorkingDir string `json:"workingDir"`
 }
 
 // Dry returns the command steps as they would be executed by the runner

--- a/internal/testutil/signing.go
+++ b/internal/testutil/signing.go
@@ -51,8 +51,8 @@ func (s TestSigner) Sign(context.Context, *intoto.Statement) (signing.Attestatio
 // TestLogEntry is a basic LogEntry implementation.
 type TestLogEntry struct {
 	IDVal       string
-	LogIndexVal int64
 	UUIDVal     string
+	LogIndexVal int64
 }
 
 // ID implements LogEntry.ID.

--- a/internal/utils/marshal_test.go
+++ b/internal/utils/marshal_test.go
@@ -41,7 +41,8 @@ func Test_MarshalToString(t *testing.T) {
 				"-tags=netgo",
 				"-ldflags=-X main.gitVersion=v1.2.3 -X main.gitSomething=somthg",
 			},
-			expected: "WyIvdXNyL2xpYi9nb29nbGUtZ29sYW5nL2Jpbi9nbyIsImJ1aWxkIiwiLW1vZD12ZW5kb3IiLCItdHJpbXBhdGgiLCItdGFncz1uZXRnbyIsIi1sZGZsYWdzPS1YIG1haW4uZ2l0VmVyc2lvbj12MS4yLjMgLVggbWFpbi5naXRTb21ldGhpbmc9c29tdGhnIl0=",
+			expected: "WyIvdXNyL2xpYi9nb29nbGUtZ29sYW5nL2Jpbi9nbyIsImJ1aWxkIiwiLW1vZD12ZW5kb3IiLCItdHJpbXBhdGgiLCItdGF" +
+				"ncz1uZXRnbyIsIi1sZGZsYWdzPS1YIG1haW4uZ2l0VmVyc2lvbj12MS4yLjMgLVggbWFpbi5naXRTb21ldGhpbmc9c29tdGhnIl0=",
 		},
 	}
 	for _, tt := range tests {
@@ -85,7 +86,8 @@ func Test_UnmarshalList(t *testing.T) {
 				"-tags=netgo",
 				"-ldflags=-X main.gitVersion=v1.2.3 -X main.gitSomething=somthg",
 			},
-			value: "WyIvdXNyL2xpYi9nb29nbGUtZ29sYW5nL2Jpbi9nbyIsImJ1aWxkIiwiLW1vZD12ZW5kb3IiLCItdHJpbXBhdGgiLCItdGFncz1uZXRnbyIsIi1sZGZsYWdzPS1YIG1haW4uZ2l0VmVyc2lvbj12MS4yLjMgLVggbWFpbi5naXRTb21ldGhpbmc9c29tdGhnIl0=",
+			value: "WyIvdXNyL2xpYi9nb29nbGUtZ29sYW5nL2Jpbi9nbyIsImJ1aWxkIiwiLW1vZD12ZW5kb3IiLCItdHJpbXBhdGgiLCItdGFncz" +
+				"1uZXRnbyIsIi1sZGZsYWdzPS1YIG1haW4uZ2l0VmVyc2lvbj12MS4yLjMgLVggbWFpbi5naXRTb21ldGhpbmc9c29tdGhnIl0=",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/utils/marshal_test.go
+++ b/internal/utils/marshal_test.go
@@ -25,8 +25,8 @@ func Test_MarshalToString(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		variables []string
 		expected  string
+		variables []string
 	}{
 		{
 			name:      "single arg",

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -28,9 +28,9 @@ func Test_PathIsUnderCurrentDirectory(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		expected error
 		name     string
 		path     string
-		expected error
 	}{
 		{
 			name:     "valid same path",
@@ -90,9 +90,9 @@ func Test_VerifyAttestationPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		expected error
 		name     string
 		path     string
-		expected error
 	}{
 		{
 			name:     "valid file",
@@ -166,10 +166,10 @@ func tempWD() (func() error, error) {
 
 func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 	tests := []struct {
+		expected     error
 		name         string
 		path         string
 		existingPath bool
-		expected     error
 	}{
 		{
 			name:     "valid file cannot create",

--- a/signing/envelope/envelope_test.go
+++ b/signing/envelope/envelope_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func intotoEntry(certPem []byte, provenance []byte) (*intotod.V001Entry, error) {
+func intotoEntry(certPem, provenance []byte) (*intotod.V001Entry, error) {
 	cert := strfmt.Base64(certPem)
 	return &intotod.V001Entry{
 		IntotoObj: models.IntotoV001Schema{
@@ -162,7 +162,7 @@ func TestAddCert(t *testing.T) {
 
 // This servers as a regression test to make sure that the Rekor intoto
 // type can successfully unmarshal our "Envelope" with included cert.
-func testRekorSupport(t *testing.T, certPem []byte, envWithCert []byte) {
+func testRekorSupport(t *testing.T, certPem, envWithCert []byte) {
 	ctx := context.Background()
 	intotoEntry, err := intotoEntry(certPem, envWithCert)
 	if err != nil {

--- a/signing/sigstore/rekor.go
+++ b/signing/sigstore/rekor.go
@@ -78,7 +78,8 @@ func (r *Rekor) Upload(ctx context.Context, att signing.Attestation) (signing.Lo
 		return nil, fmt.Errorf("retrieving log uuid by index: %w", err)
 	}
 	var uuid string
-	for ix, entry := range resp.Payload {
+	for ix := range resp.Payload {
+		entry := resp.Payload[ix]
 		if err := cosign.VerifyTLogEntry(ctx, rekorClient, &entry); err != nil {
 			return nil, fmt.Errorf("validating log entry: %w", err)
 		}

--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -53,9 +53,9 @@ type BuildType interface {
 
 // GithubActionsBuild is a basic build type for builders running in GitHub Actions.
 type GithubActionsBuild struct {
-	subject []intoto.Subject
 	Context github.WorkflowContext
 	Clients ClientProvider
+	subject []intoto.Subject
 }
 
 // WorkflowParameters contains parameters given to the workflow invocation.

--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -66,10 +66,10 @@ type WorkflowParameters struct {
 
 // NewGithubActionsBuild returns a new GithubActionsBuild that uses the
 // GitHub context to generate information.
-func NewGithubActionsBuild(s []intoto.Subject, c github.WorkflowContext) *GithubActionsBuild {
+func NewGithubActionsBuild(s []intoto.Subject, c *github.WorkflowContext) *GithubActionsBuild {
 	return &GithubActionsBuild{
 		subject: s,
-		Context: c,
+		Context: *c,
 		Clients: &DefaultClientProvider{},
 	}
 }
@@ -85,7 +85,7 @@ func (b *GithubActionsBuild) BuildConfig(context.Context) (interface{}, error) {
 	return nil, nil
 }
 
-func addEnvKeyString(m map[string]interface{}, k string, v string) {
+func addEnvKeyString(m map[string]interface{}, k, v string) {
 	// Always record the value, even if it's empty. Let
 	// the consumer/verifier decide how to interpret their meaning.
 	m[k] = v

--- a/slsa/provenance_test.go
+++ b/slsa/provenance_test.go
@@ -41,7 +41,7 @@ func TestHostedActionsProvenance(t *testing.T) {
 		{
 			name: "empty",
 			b: &TestBuild{
-				GithubActionsBuild: NewGithubActionsBuild(nil, github.WorkflowContext{}).WithClients(&NilClientProvider{}),
+				GithubActionsBuild: NewGithubActionsBuild(nil, &github.WorkflowContext{}).WithClients(&NilClientProvider{}),
 			},
 			token: &github.OIDCToken{
 				Audience: []string{""},
@@ -80,7 +80,7 @@ func TestHostedActionsProvenance(t *testing.T) {
 		{
 			name: "invocation env",
 			b: &TestBuild{
-				GithubActionsBuild: NewGithubActionsBuild(nil, github.WorkflowContext{
+				GithubActionsBuild: NewGithubActionsBuild(nil, &github.WorkflowContext{
 					RunID:      "12345",
 					RunAttempt: "1",
 					EventName:  "pull_request",

--- a/slsa/provenance_test.go
+++ b/slsa/provenance_test.go
@@ -33,10 +33,10 @@ func TestHostedActionsProvenance(t *testing.T) {
 	now := time.Date(2022, 4, 14, 12, 24, 0, 0, time.UTC)
 
 	testCases := []struct {
-		name     string
 		b        BuildType
 		token    *github.OIDCToken
 		expected *intoto.ProvenanceStatement
+		name     string
 	}{
 		{
 			name: "empty",


### PR DESCRIPTION
Updates #450 

Suggestion to enable some of the missing linters mentioned in https://github.com/slsa-framework/slsa-github-generator/issues/450

I started out with the most easy / clear ones. I am happy to help out with enabling further checkers if you think these changes go into a good direction 🙂  

I've split each checker and their respective changes into a single commit so we can easily revert and drop certain checkers if you think the changes a checker proposes are not valuable for the code base afterall. `govet` for example proposed a lot of changes to reshuffle struct fields which improves memory utilization, but might decrease code readbility (IMHO) by requiring a certain order of fields where its impossible to group things that are closely related. 

Let me know what you think! 