### PR TITLE
Update golang image sha

### DIFF
--- a/.github/actions/detect-workflow/Dockerfile
+++ b/.github/actions/detect-workflow/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.4@sha256:cfaad8202aed5121121dfe3a252e98d5c89cc67fc456cc69fe70eb7dcc1b8cff as builder
+FROM golang:1.19.4@sha256:941582ed5a1189ce2c8cf6a806cfb8f5924694e1f58856869f98364315de6231 as builder
 
 WORKDIR /app
 COPY . /app

--- a/.github/workflows/scripts/verify-base-images.sh
+++ b/.github/workflows/scripts/verify-base-images.sh
@@ -17,28 +17,29 @@ set -euo pipefail
 
 # NOTE: Use read to avoid whitespace issues.
 find . \( ! -name vendor -o -prune \) \( ! -name node_modules -o -prune \) -type f -name Dockerfile -print0 | while IFS= read -r -d '' f; do
-    echo "Checking $f"
-    grep "^FROM " "$f" | while IFS= read -r line; do
-        image_full=$(echo "$line" | awk '{ print $2 }')
-        image_name=$(echo "$image_full" | cut -d '@' -f 1)
-        image_sha=$(echo "$image_full" | cut -d '@' -f 2- | cut -d ':' -f 2-)
+    echo "Checking ${f}"
+    grep "^FROM " "${f}" | while IFS= read -r line; do
+        image_full=$(echo "${line}" | awk '{ print $2 }')
+        image_name=$(echo "${image_full}" | cut -d '@' -f 1 | cut -d ':' -f 1)
+        image_tag=$(echo "${image_full}" | cut -d '@' -f 1 | cut -d ':' -f 2)
+        image_sha=$(echo "${image_full}" | cut -d '@' -f 2- | cut -d ':' -f 2-)
 
-        echo "Verifying base image $image_full"
+        echo "Verifying base image ${image_full}"
 
         # verify that the image contains a sha.
-        if [ "$image_sha" == "" ]; then
-            echo "\"$image_full\" should be referenced by digest."
+        if [ "${image_sha}" == "" ]; then
+            echo "\"${image_full}\" should be referenced by digest."
             exit 2
         fi
 
         # verify distroless base images.
-        if [[ "$image_name" == gcr.io/distroless/* ]]; then
+        if [[ "${image_name}" == gcr.io/distroless/* ]]; then
             # verify the image signature.
             cosign verify --key .github/workflows/scripts/distroless.pub "$image_full"
         else
             # All other base images should be signed using Docker Content Trust.
-            if ! (DOCKER_CONTENT_TRUST=1 docker trust inspect --pretty "$image_name" | sed -n 5p | grep "$image_sha"); then
-                echo "$image_full: unable to verify Docker Content Trust."
+            if ! (DOCKER_CONTENT_TRUST=1 docker trust inspect "${image_name}:${image_tag}" | jq -r ".[].SignedTags | .[] | select(.SignedTag == \"${image_tag}\") | .Digest" | grep "${image_sha}"); then
+                echo "${image_full}: unable to verify Docker Content Trust."
                 exit 2
             fi
         fi

--- a/.github/workflows/scripts/verify-base-images.sh
+++ b/.github/workflows/scripts/verify-base-images.sh
@@ -37,7 +37,7 @@ find . \( ! -name vendor -o -prune \) \( ! -name node_modules -o -prune \) -type
             cosign verify --key .github/workflows/scripts/distroless.pub "$image_full"
         else
             # All other base images should be signed using Docker Content Trust.
-            if ! (DOCKER_CONTENT_TRUST=1 docker trust inspect --pretty "$image_name" | grep "$image_sha"); then
+            if ! (DOCKER_CONTENT_TRUST=1 docker trust inspect --pretty "$image_name" | sed -n 5p | grep "$image_sha"); then
                 echo "$image_full: unable to verify Docker Content Trust."
                 exit 2
             fi


### PR DESCRIPTION
Updates #1401

Also updates the verification script to only check the SHA of the image rather than the whole output of the `docker trust inspect` command.

Signed-off-by: Ian Lewis <ianlewis@google.com>