### PR TITLE
fix: existing vuln in json5

### DIFF
--- a/.github/actions/generate-attestations/action.yml
+++ b/.github/actions/generate-attestations/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'A JSON file describing the SLSA output layout with attestation filename keys and the generated subjects (and digests)'
     required: true
   predicate-type:
-    description: 'A URI dedining the type of the predicate, for e.g. https://slsa.dev/provenance/v0.2'
+    description: 'A URI defining the type of the predicate, for e.g. https://slsa.dev/provenance/v0.2'
     required: true
   predicate-file:
     description: 'A JSON file describing the SLSA predicate to attach to the subjects'

--- a/.github/actions/generate-attestations/package-lock.json
+++ b/.github/actions/generate-attestations/package-lock.json
@@ -4854,9 +4854,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -10398,9 +10398,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"


### PR DESCRIPTION
Signed-off-by: laurentsimon <laurentsimon@google.com>

This PR updates json5 dependency.

```shell
$ npm audit report

json5  <1.0.2
Severity: high
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
fix available via `npm audit fix`
node_modules/json5

1 high severity vulnerability
```