### PR TITLE
chore: Improve config parsing error messages

### DIFF
--- a/internal/builders/go/pkg/config.go
+++ b/internal/builders/go/pkg/config.go
@@ -76,15 +76,19 @@ func configFromString(b []byte) (*GoReleaserConfig, error) {
 // from it.
 func ConfigFromFile(path string) (*GoReleaserConfig, error) {
 	if err := validatePath(path); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%q: %w", path, err)
 	}
 
 	cfg, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		return nil, fmt.Errorf("os.ReadFile: %w", err)
+		return nil, fmt.Errorf("%q: os.ReadFile: %w", path, err)
 	}
 
-	return configFromString(cfg)
+	c, err := configFromString(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("%q: %w", path, err)
+	}
+	return c, nil
 }
 
 func fromConfig(cf *goReleaserConfigFile) (*GoReleaserConfig, error) {
@@ -161,7 +165,7 @@ func convertPathError(e error, msg string) error {
 func validateVersion(cf *goReleaserConfigFile) error {
 	_, exists := supportedVersions[cf.Version]
 	if !exists {
-		return fmt.Errorf("%w:%d", ErrorUnsupportedVersion, cf.Version)
+		return fmt.Errorf("%w: %d", ErrorUnsupportedVersion, cf.Version)
 	}
 
 	return nil

--- a/internal/builders/go/pkg/config_test.go
+++ b/internal/builders/go/pkg/config_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func errCmp(e1, e2 error) bool {
@@ -174,7 +175,7 @@ func Test_ConfigFromFile(t *testing.T) {
 			cfg, err := ConfigFromFile(tt.path)
 
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
Adds config file path to error messages to make it clearer these are error messages that occurred during config parsing.

Signed-off-by: Ian Lewis <ianlewis@google.com>