### PR TITLE
feat(docker): update docker based workflow to use buildDefinition and sign

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -23,6 +23,8 @@ env:
   # Builder.
   BUILDER_BINARY: slsa-builder-docker-linux-amd64 # Name of the binary in the release assets.
   BUILDER_DIR: internal/builders/docker # Source directory if we compile the builder.
+  # Outputs folder.
+  OUTPUT_FOLDER: outputs
 
 defaults:
   run:
@@ -171,7 +173,7 @@ jobs:
           allow-private-repository: ${{ inputs.private-repository }}
 
       - name: Upload builder
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: "${{ env.BUILDER_BINARY }}-${{ needs.rng.outputs.value }}"
           path: "${{ env.BUILDER_BINARY }}"
@@ -211,10 +213,10 @@ jobs:
           SOURCE_DIGEST: ${{ inputs.source-digest }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
-          if [ -z "$SOURCE_DIGEST" ]; then 
+          if [ -z "$SOURCE_DIGEST" ]; then
             ref=$(echo ${SOURCE_DIGEST} | cut -d':' -f2)
             echo "ref=$ref" >> $GITHUB_OUTPUT
-          else 
+          else
             echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
 
@@ -245,18 +247,18 @@ jobs:
 
           # Note: this outputs information about resolved arguments, etc.
           # the values are trusted because the compiler is not invoked.
-          echo "$GITHUB_WORKSPACE/$BUILDER_BINARY" dry-run \
-            --build-config-path ${CONFIG_PATH} \
+          echo "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
+            --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
-            --builder-image ${BUILDER_IMAGE}@${BUILDER_DIGEST} \
-            --git-commit-hash ${SOURCE_DIGEST} \
-            --source-repo git+https://github.com/${SOURCE_REPOSITORY}
-          "$GITHUB_WORKSPACE/$BUILDER_BINARY" dry-run \
-            --build-config-path ${CONFIG_PATH} \
+            --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
+            --git-commit-hash "${SOURCE_DIGEST}" \
+            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
+          "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
+            --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
-            --builder-image ${BUILDER_IMAGE}@${BUILDER_DIGEST} \
-            --git-commit-hash ${SOURCE_DIGEST} \
-            --source-repo git+https://github.com/${SOURCE_REPOSITORY}
+            --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
+            --git-commit-hash "${SOURCE_DIGEST}" \
+            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 
@@ -332,7 +334,7 @@ jobs:
     needs: [rng, detect-env, build, generate-build-definition, generate-builder]
     permissions:
       id-token: write # Needed to create an OIDC token for keyless signing.
-      contents: read
+      contents: read  # Needed to check out the repository.
       actions: read # Needed to read workflow info.
     outputs:
       provenance: ${{ steps.sign.outputs.output-name }}
@@ -388,10 +390,10 @@ jobs:
 
       - name: Upload unsigned intoto attestations file for pull request
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
-          name: "attestations-${{ needs.rng.outputs.value }}"
-          path: "attestations"
+          name: "${{ env.OUTPUT_FOLDER }}"
+          path: "attestations-${{ needs.rng.outputs.value }}"
           if-no-files-found: error
 
       ###################################################################
@@ -403,14 +405,13 @@ jobs:
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/sign-attestations
         with:
           attestations: "attestations-${{ needs.rng.outputs.value }}"
-          output-folder: "outputs"
+          output-folder: "${{ env.OUTPUT_FOLDER }}"
 
       - name: Upload the signed attestations
         id: upload
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
-          name: "outputs"
-          path: "outputs"
+          name: "${{ env.OUTPUT_FOLDER }}"
+          path: "${{ env.OUTPUT_FOLDER }}"
           if-no-files-found: error
-

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -68,22 +68,6 @@ on:
         required: false
         type: string
         default: 'output/**'
-      source-repository:
-        description: >
-          Source repository to checkout for the build. For example, octocat/hello-world.
-          The builder will mount the root of this source repository to the workspace.
-
-          By default, uses the source repository of the caller workflow.
-        required: false
-        type: string
-      source-digest:
-        description: >
-          The SHA of the source repository to checkout. The digest is of the form
-          '<alg>:<digest>'.
-
-          By default, uses the source repository of the caller workflow.
-        required: false
-        type: string
       compile-builder:
         description: "Build the builder from source. This increases build time by ~2m."
         required: false
@@ -207,18 +191,6 @@ jobs:
           sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
           set-executable: true
 
-      - name: Get source ref
-        id: resolve
-        env:
-          SOURCE_DIGEST: ${{ inputs.source-digest }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          if [ -z "$SOURCE_DIGEST" ]; then
-            echo "ref=${SOURCE_DIGEST}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=sha1:$GITHUB_SHA" >> $GITHUB_OUTPUT
-          fi
-
       - name: Generate build definition
         id: generate
         # These are the inputs, it may be with: for an action or
@@ -227,10 +199,6 @@ jobs:
           BUILDER_IMAGE: ${{ inputs.builder-image }}
           BUILDER_DIGEST: ${{ inputs.builder-digest }}
           CONFIG_PATH: ${{ inputs.config-path }}
-          # Either the provided source repository or the caller's GITHUB_REPOSITORY
-          SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
-          # Either the provided digest, or the caller's GITHUB_REF
-          SOURCE_DIGEST: ${{ steps.resolve.outputs.ref }}
         run: |
           set -euo pipefail
 
@@ -240,14 +208,14 @@ jobs:
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-digest "${SOURCE_DIGEST}" \
-            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
+            --git-commit-digest "sha1:${GITHUB_SHA}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}"
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-digest "${SOURCE_DIGEST}" \
-            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
+            --git-commit-digest "sha1:${GITHUB_SHA}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 
@@ -289,18 +257,6 @@ jobs:
           sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
           set-executable: true
 
-      - name: Get source ref
-        id: resolve
-        env:
-          SOURCE_DIGEST: ${{ inputs.source-digest }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          if [ -z "$SOURCE_DIGEST" ]; then
-            echo "ref=${SOURCE_DIGEST}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=sha1:$GITHUB_SHA" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run builder binary
         id: build
         # These are the inputs, it may be with: for an action or
@@ -309,10 +265,7 @@ jobs:
           BUILDER_IMAGE: ${{ inputs.builder-image }}
           BUILDER_DIGEST: ${{ inputs.builder-digest }}
           CONFIG_PATH: ${{ inputs.config-path }}
-          # Either the provided source repository or the caller's GITHUB_REPOSITORY
-          SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
-          # Either the provided digest, or the caller's GITHUB_REF
-          SOURCE_DIGEST: ${{ steps.resolve.outputs.ref }}
+
         run: |
           set -euo pipefail
 
@@ -321,15 +274,15 @@ jobs:
           echo "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-digest "${SOURCE_DIGEST}" \
-            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}" \
+            --git-commit-digest "sha1:${GITHUB_SHA}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
             --subjects-path subjects.json \
             --force-checkout
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-digest "${SOURCE_DIGEST}" \
-            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}" \
+            --git-commit-digest "sha1:${GITHUB_SHA}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
             --subjects-path subjects.json \
             --force-checkout
 

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -401,6 +401,7 @@ jobs:
       ###################################################################
 
       - name: Sign attestations
+        if: ${{ github.event_name != 'pull_request' }}
         id: sign
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/sign-attestations
         with:

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -285,7 +285,6 @@ jobs:
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
             --subjects-path subjects.json \
             --force-checkout
-
           
           cat <<EOF >DATA
           {

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -257,8 +257,16 @@ jobs:
           sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
           set-executable: true
 
+      - name: Checkout the source repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          path: __PROJECT_CHECKOUT_DIR__
+
       - name: Run builder binary
         id: build
+        working-directory: __PROJECT_CHECKOUT_DIR__
         # These are the inputs, it may be with: for an action or
         # specified with these env vars.
         env:
@@ -276,15 +284,13 @@ jobs:
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
-            --subjects-path subjects.json \
-            --force-checkout
+            --subjects-path subjects.json
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
-            --subjects-path subjects.json \
-            --force-checkout
+            --subjects-path subjects.json
           
           cat <<EOF >DATA
           {

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -306,7 +306,7 @@ jobs:
 
           cat DATA > output-template.json
 
-          jq --argjson subjects "$(<subjects.json)" '.attestations[0].subjects += $subjects' output-template.json > slsa-outputs.json
+          jq --argjson subjects "$(<subjects.json)" '.attestations[0].subjects += $subjects' output-template.json > "${GITHUB_WORKSPACE}"/slsa-outputs.json
           echo "slsa-outputs-name=slsa-outputs.json" >> $GITHUB_OUTPUT
 
       - name: Upload the SLSA outputs file

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -214,10 +214,9 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           if [ -z "$SOURCE_DIGEST" ]; then
-            ref=$(echo ${SOURCE_DIGEST} | cut -d':' -f2)
-            echo "ref=$ref" >> $GITHUB_OUTPUT
+            echo "ref=${SOURCE_DIGEST}" >> $GITHUB_OUTPUT
           else
-            echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+            echo "ref=sha1:$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate build definition
@@ -297,10 +296,9 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           if [ -z "$SOURCE_DIGEST" ]; then
-            ref=$(echo ${SOURCE_DIGEST} | cut -d':' -f2)
-            echo "ref=$ref" >> $GITHUB_OUTPUT
+            echo "ref=${SOURCE_DIGEST}" >> $GITHUB_OUTPUT
           else
-            echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+            echo "ref=sha1:$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
 
       - name: Run builder binary

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -17,7 +17,12 @@ name: SLSA Docker-based builder
 permissions:
   contents: read
 
-# TODO: env vars for builder
+env:
+  # Project.
+  GENERATED_BINARY_NAME: docker-compiled-binary
+  # Builder.
+  BUILDER_BINARY: slsa-builder-docker-linux-amd64 # Name of the binary in the release assets.
+  BUILDER_DIR: internal/builders/docker # Source directory if we compile the builder.
 
 defaults:
   run:
@@ -77,6 +82,11 @@ on:
           By default, uses the source repository of the caller workflow.
         required: false
         type: string
+      compile-builder:
+        description: "Build the builder from source. This increases build time by ~2m."
+        required: false
+        type: boolean
+        default: false
       private-repository:
         description: "If true, private repositories can post to the public transparency log."
         required: false
@@ -143,15 +153,30 @@ jobs:
     # TODO: would it be convenient to output the builderDependency?
     # TODO: this is a no-op right now. Replace with final builder.
     outputs:
-      builder-binary-sha256: ${{ steps.generate-builder.outputs.sha256 }}
-    needs: detect-env
+      builder-binary-sha256: ${{ steps.generate.outputs.sha256 }}
+    needs: [detect-env, rng]
     runs-on: ubuntu-latest
     steps:
-      - name: Generate the builder binary
-        id: generate-builder
-        run: |
-          echo "fetches the builder binary and uploads it"
-          echo "sha256=5b36fa157544ece32dba62c14480d85322b86918032ca5f40b87f5d1dc386d39" >> $GITHUB_OUTPUT
+      - name: Generate builder binary
+        id: generate
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@main
+        with:
+          repository: "${{ needs.detect-env.outputs.repository }}"
+          ref: "${{ needs.detect-env.outputs.ref }}"
+          go-version: 1.19
+          # Note: This must be the non-randomized binary name, so that it can be downloaded from the release assets.
+          binary: "${{ env.BUILDER_BINARY }}"
+          compile-builder: "${{ inputs.compile-builder }}"
+          directory: "${{ env.BUILDER_DIR }}"
+          allow-private-repository: ${{ inputs.private-repository }}
+
+      - name: Upload builder
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+        with:
+          name: "${{ env.BUILDER_BINARY }}-${{ needs.rng.outputs.value }}"
+          path: "${{ env.BUILDER_BINARY }}"
+          if-no-files-found: error
+          retention-days: 5
 
   ###################################################################
   #                                                                 #
@@ -159,62 +184,12 @@ jobs:
   #                                                                 #
   ###################################################################
   generate-build-definition:
-    # TODO: Use the builder binary.
     outputs:
       build-definition-name: ${{ steps.generate.outputs.build-definition-name }}
       build-definition-sha256: ${{ steps.upload.outputs.sha256 }}
     runs-on: ubuntu-latest
-    needs: [detect-env, verify-builder-image]
+    needs: [rng, detect-env, verify-builder-image, generate-builder]
     steps:
-      - name: Generate build definition
-        id: generate
-        # These are the inputs, it may be with: for an action or
-        # specified with these env vars.
-        env:
-          BUILDER_IMAGE: ${{ inputs.builder-image }}
-          BUILDER_DIGEST: ${{ inputs.builder-digest }}
-          BUILDER_VERIFIED: ${{ needs.verify-builder-image.outputs.verified }}
-          CONFIG_PATH: ${{ inputs.config-path }}
-          OUTPUT: ${{ inputs.builder-output-path }}
-          # Either the provided source repository or the caller's GITHUB_REPOSITORY
-          SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
-          # Either the provided digest, or the caller's GITHUB_REF
-          SOURCE_DIGEST: ${{ inputs.source-digest || github.ref }}
-        run: |
-          # Run builder binary and produce buildDefinition
-          # TODO: Insert verified builder image provenance into resolvedDep
-          echo "run resolution and output buildDefinition!"
-
-          SOURCE_ALG=${SOURCE_DIGEST%%:*}
-          SOURCE_DIGEST=${SOURCE_DIGEST#*:}
-
-          IMAGE_ALG=${BUILDER_DIGEST%%:*}
-          IMAGE_DIGEST=${BUILDER_DIGEST#*:}
-
-          cat <<EOF >DATA
-          {
-            "buildType": "https://slsa.dev/container-based-build/v0.1?draft",
-            "externalParameters": {
-                "artifacts": {
-                  "source": {
-                    "uri": "git+https://github.com/${SOURCE_REPOSITORY}@${SOURCE_DIGEST}",
-                    "digest": { "$SOURCE_ALG": "$SOURCE_DIGEST" }
-                  },
-                  "builderImage": {
-                    "uri": "${BUILDER_IMAGE}",
-                    "digest": { "$IMAGE_ALG": "$IMAGE_DIGEST" }
-                  }
-                },
-                "values": {
-                  "configFile": "${CONFIG_PATH}"
-                }
-            },
-          }
-          EOF
-
-          cat DATA > build-definition.json
-          echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
-
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
@@ -222,11 +197,74 @@ jobs:
           ref: "${{ needs.detect-env.outputs.ref }}"
           path: __BUILDER_CHECKOUT_DIR__
 
+      - name: Download builder
+        uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-download-artifact
+        with:
+          name: "${{ env.BUILDER_BINARY }}-${{ needs.rng.outputs.value }}"
+          path: "${{ env.BUILDER_BINARY }}"
+          sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
+          set-executable: true
+
+      - name: Get source ref
+        id: resolve
+        env:
+          SOURCE_DIGEST: ${{ inputs.source-digest }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$SOURCE_DIGEST" ]; then 
+            ref=$(echo ${SOURCE_DIGEST} | cut -d':' -f2)
+            echo "ref=$ref" >> $GITHUB_OUTPUT
+          else 
+            echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          fi
+
+      # TODO: Use secure-checkout, but this requires configuring the source-repository.
+      - name: Checkout the source repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          path: __PROJECT_CHECKOUT_DIR__
+          repository: ${{ inputs.source-repository || github.repository }}
+          ref: ${{ steps.resolve.outputs.ref }}
+
+      - name: Generate build definition
+        id: generate
+        # These are the inputs, it may be with: for an action or
+        # specified with these env vars.
+        env:
+          BUILDER_IMAGE: ${{ inputs.builder-image }}
+          BUILDER_DIGEST: ${{ inputs.builder-digest }}
+          CONFIG_PATH: ${{ inputs.config-path }}
+          # Either the provided source repository or the caller's GITHUB_REPOSITORY
+          SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
+          # Either the provided digest, or the caller's GITHUB_REF
+          SOURCE_DIGEST: ${{ inputs.source-digest || github.ref }}
+        run: |
+          set -euo pipefail
+
+          # Note: this outputs information about resolved arguments, etc.
+          # the values are trusted because the compiler is not invoked.
+          echo "$GITHUB_WORKSPACE/$BUILDER_BINARY" dry-run \
+            --build-config-path ${CONFIG_PATH} \
+            --build-definition-path build-definition.json \
+            --builder-image ${BUILDER_IMAGE}@${BUILDER_DIGEST} \
+            --git-commit-hash ${SOURCE_DIGEST} \
+            --source-repo git+https://github.com/${SOURCE_REPOSITORY}
+          "$GITHUB_WORKSPACE/$BUILDER_BINARY" dry-run \
+            --build-config-path ${CONFIG_PATH} \
+            --build-definition-path build-definition.json \
+            --builder-image ${BUILDER_IMAGE}@${BUILDER_DIGEST} \
+            --git-commit-hash ${SOURCE_DIGEST} \
+            --source-repo git+https://github.com/${SOURCE_REPOSITORY}
+
+          echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
+
       - name: Upload the build definition file
         id: upload
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-upload-artifact
         with:
-          name: "${{ steps.generate.outputs.build-definition-name }}"
+          name: "${{ steps.generate.outputs.build-definition-name }}-${{ needs.rng.outputs.value }}"
           path: "${{ steps.generate.outputs.build-definition-name }}"
 
   ###################################################################
@@ -242,7 +280,7 @@ jobs:
       slsa-outputs-name: ${{ steps.build.outputs.slsa-outputs-name }}
       # The digest of the SLSA subject outputs file for secure download.
       slsa-outputs-sha256: ${{ steps.upload.outputs.sha256 }}
-    needs: [detect-env, generate-builder]
+    needs: [rng, detect-env, generate-builder]
     # TODO: Replace with builder binary
     steps:
       - name: Run builder binary
@@ -281,7 +319,7 @@ jobs:
         id: upload
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-upload-artifact
         with:
-          name: "${{ steps.build.outputs.slsa-outputs-name }}"
+          name: "${{ steps.build.outputs.slsa-outputs-name }}-${{ needs.rng.outputs.value }}"
           path: "${{ steps.build.outputs.slsa-outputs-name }}"
 
   ###################################################################
@@ -292,6 +330,10 @@ jobs:
   provenance:
     runs-on: ubuntu-latest
     needs: [rng, detect-env, build, generate-build-definition, generate-builder]
+    permissions:
+      id-token: write # Needed to create an OIDC token for keyless signing.
+      contents: read
+      actions: read # Needed to read workflow info.
     outputs:
       provenance: ${{ steps.sign.outputs.output-name }}
     steps:
@@ -305,7 +347,7 @@ jobs:
       - name: Download build definition
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-download-artifact
         with:
-          name: "${{ needs.generate-build-definition.outputs.build-definition-name }}"
+          name: "${{ needs.generate-build-definition.outputs.build-definition-name }}-${{ needs.rng.outputs.value }}"
           path: "${{ needs.generate-build-definition.outputs.build-definition-name }}"
           sha256: "${{ needs.generate-build-definition.outputs.build-definition-sha256 }}"
 
@@ -324,28 +366,6 @@ jobs:
       #     binary-name: "internal/builders/docker-based/cmd/build"
       #     binary-repository: "${{ needs.detect-env.outputs.repository }}"
       #     binary-ref: "${{ needs.detect-env.outputs.ref }}"
-      - name: Create predicate
-        id: predicate
-        run: |
-          cat <<EOF >DATA
-          {
-            "version": 1,
-             "attestations": [
-              {
-                "name": "attestation1.intoto",
-                "subjects": [
-                  { "name": "artifact11",
-                    "digest": { "sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef" }},
-                  { "name": "artifact12",
-                    "digest": { "sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2" }}
-                ]
-              }
-            ]
-          }
-          EOF
-
-          cat DATA > predicate.json
-          echo "predicate=predicate.json" >> $GITHUB_OUTPUT
 
       ###################################################################
       #                Generate the intoto attestations                 #
@@ -354,7 +374,7 @@ jobs:
       - name: Download SLSA outputs
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-download-artifact
         with:
-          name: "${{ needs.build.outputs.slsa-outputs-name }}"
+          name: "${{ needs.build.outputs.slsa-outputs-name }}-${{ needs.rng.outputs.value }}"
           path: "${{ needs.build.outputs.slsa-outputs-name }}"
           sha256: "${{ needs.build.outputs.slsa-outputs-sha256 }}"
 
@@ -363,7 +383,7 @@ jobs:
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/generate-attestations
         with:
           slsa-outputs-file: "${{ needs.build.outputs.slsa-outputs-name }}"
-          predicate-file: "${{ steps.predicate.outputs.predicate }}"
+          predicate-file: "${{ needs.generate-build-definition.outputs.build-definition-name }}"
           output-folder: "attestations-${{ needs.rng.outputs.value }}"
 
       - name: Upload unsigned intoto attestations file for pull request
@@ -371,32 +391,26 @@ jobs:
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
         with:
           name: "attestations-${{ needs.rng.outputs.value }}"
-          path: "attestations-${{ needs.rng.outputs.value }}"
+          path: "attestations"
+          if-no-files-found: error
 
       ###################################################################
       #                       Sign the attestation                      #
       ###################################################################
 
-      # - name: Sign attestations
-      #   id: sign
-      #   uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/sign-attestations
-      #   with:
-      #     attestations: "${{ needs.attest.outputs.attestations-name }}"
-      #     bundle: false
-
       - name: Sign attestations
         id: sign
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          mkdir envelope
-          echo "{}" > envelope/envelope1.json
-          echo "{}" > envelope/envelope2.json
-          echo "outputs=envelope/" >> $GITHUB_OUTPUT
+        uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/sign-attestations
+        with:
+          attestations: "attestations-${{ needs.rng.outputs.value }}"
+          output-folder: "outputs"
 
       - name: Upload the signed attestations
         id: upload
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
         with:
-          name: outputs
-          path: "${{ steps.sign.outputs.outputs }}"
+          name: "outputs"
+          path: "outputs"
+          if-no-files-found: error
+

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -220,16 +220,6 @@ jobs:
             echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
 
-      # TODO: Use secure-checkout, but this requires configuring the source-repository.
-      - name: Checkout the source repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-          path: __PROJECT_CHECKOUT_DIR__
-          repository: ${{ inputs.source-repository || github.repository }}
-          ref: ${{ steps.resolve.outputs.ref }}
-
       - name: Generate build definition
         id: generate
         # These are the inputs, it may be with: for an action or
@@ -241,7 +231,7 @@ jobs:
           # Either the provided source repository or the caller's GITHUB_REPOSITORY
           SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
           # Either the provided digest, or the caller's GITHUB_REF
-          SOURCE_DIGEST: ${{ inputs.source-digest || github.ref }}
+          SOURCE_DIGEST: ${{ steps.resolve.outputs.ref }}
         run: |
           set -euo pipefail
 
@@ -251,13 +241,13 @@ jobs:
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-hash "${SOURCE_DIGEST}" \
+            --git-commit-digest "${SOURCE_DIGEST}" \
             --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
-            --git-commit-hash "${SOURCE_DIGEST}" \
+            --git-commit-digest "${SOURCE_DIGEST}" \
             --source-repo "git+https://github.com/${SOURCE_REPOSITORY}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
@@ -285,37 +275,83 @@ jobs:
     needs: [rng, detect-env, generate-builder]
     # TODO: Replace with builder binary
     steps:
-      - name: Run builder binary
-        id: build
-        run: |
-          echo "run builder and output subjects!"
-
-          cat <<EOF >DATA
-          {
-            "version": 1,
-             "attestations": [
-              {
-                "name": "attestation1.intoto",
-                "subjects": [
-                  { "name": "artifact11",
-                    "digest": { "sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef" }},
-                  { "name": "artifact12",
-                    "digest": { "sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2" }}
-                ]
-              }
-            ]
-          }
-          EOF
-
-          cat DATA > slsa-outputs.json
-          echo "slsa-outputs-name=slsa-outputs.json" >> $GITHUB_OUTPUT
-
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
           path: __BUILDER_CHECKOUT_DIR__
+
+      - name: Download builder
+        uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-download-artifact
+        with:
+          name: "${{ env.BUILDER_BINARY }}-${{ needs.rng.outputs.value }}"
+          path: "${{ env.BUILDER_BINARY }}"
+          sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
+          set-executable: true
+
+      - name: Get source ref
+        id: resolve
+        env:
+          SOURCE_DIGEST: ${{ inputs.source-digest }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$SOURCE_DIGEST" ]; then
+            ref=$(echo ${SOURCE_DIGEST} | cut -d':' -f2)
+            echo "ref=$ref" >> $GITHUB_OUTPUT
+          else
+            echo "ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run builder binary
+        id: build
+        # These are the inputs, it may be with: for an action or
+        # specified with these env vars.
+        env:
+          BUILDER_IMAGE: ${{ inputs.builder-image }}
+          BUILDER_DIGEST: ${{ inputs.builder-digest }}
+          CONFIG_PATH: ${{ inputs.config-path }}
+          # Either the provided source repository or the caller's GITHUB_REPOSITORY
+          SOURCE_REPOSITORY: ${{ inputs.source-repository || github.repository }}
+          # Either the provided digest, or the caller's GITHUB_REF
+          SOURCE_DIGEST: ${{ steps.resolve.outputs.ref }}
+        run: |
+          set -euo pipefail
+
+          # Note: this outputs information about resolved arguments, etc.
+          # the values are trusted because the compiler is not invoked.
+          echo "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
+            --build-config-path "${CONFIG_PATH}" \
+            --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
+            --git-commit-digest "${SOURCE_DIGEST}" \
+            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}" \
+            --subjects-path subjects.json \
+            --force-checkout
+          "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
+            --build-config-path "${CONFIG_PATH}" \
+            --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
+            --git-commit-digest "${SOURCE_DIGEST}" \
+            --source-repo "git+https://github.com/${SOURCE_REPOSITORY}" \
+            --subjects-path subjects.json \
+            --force-checkout
+
+          
+          cat <<EOF >DATA
+          {
+            "version": 1,
+             "attestations": [
+              {
+                "name": "attestation1.intoto",
+                "subjects": []
+              }
+            ]
+          }
+          EOF
+
+          cat DATA > output-template.json
+
+          jq --argjson subjects "$(<subjects.json)" '.attestations[0].subjects += $subjects' output-template.json > slsa-outputs.json
+          echo "slsa-outputs-name=slsa-outputs.json" >> $GITHUB_OUTPUT
 
       - name: Upload the SLSA outputs file
         id: upload

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -291,7 +291,7 @@ jobs:
             --git-commit-digest "sha1:${GITHUB_SHA}" \
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
             --subjects-path subjects.json
-          
+
           cat <<EOF >DATA
           {
             "version": 1,

--- a/.github/workflows/pre-submit.e2e.docker-based.default.yml
+++ b/.github/workflows/pre-submit.e2e.docker-based.default.yml
@@ -18,8 +18,9 @@ jobs:
       actions: read # For reading workflow info.
     uses: ./.github/workflows/builder_docker-based_slsa3.yml
     with:
-      source-repository: "bcoe/slsa-on-github-test"
-      source-digest: "sha1:167d361e9831e9b13f1283e2014d0cb0c6fa65f6817790597df7ee488883fb03"
-      builder-image: "pkg:oci/builder-image?repository_url=gcr.io"
-      builder-digest: "sha256:7d8e3642927faefa5e907ab011001dbc1fca9a3e28c99d7bd97ff6c50ff6c42b"
-      config-path: "path/to/config.toml"
+      source-repository: "slsa-framework/slsa-github-generator"
+      source-digest: "sha1:cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"
+      builder-image: "bash"
+      builder-digest: "sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
+      config-path: "internal/builders/docker/testdata/config.toml"
+      compile-builder: true

--- a/.github/workflows/pre-submit.e2e.docker-based.default.yml
+++ b/.github/workflows/pre-submit.e2e.docker-based.default.yml
@@ -18,8 +18,6 @@ jobs:
       actions: read # For reading workflow info.
     uses: ./.github/workflows/builder_docker-based_slsa3.yml
     with:
-      source-repository: "slsa-framework/slsa-github-generator"
-      source-digest: "sha1:cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"
       builder-image: "bash"
       builder-digest: "sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
       config-path: "internal/builders/docker/testdata/config.toml"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This updates the docker based workflow to use the resolved `buildDefinition` and completes the workflow to sign the attestation. The presubmit is also updated to be functional.

Passing run: https://github.com/asraa/slsa-github-generator/actions/runs/3878872921

The next missing pieces:
* Populate rest of predicate with GH context

Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1499

cc @rbehjati 