### PR TITLE
docs: Add instructions for release candidates to RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,17 +40,18 @@ This is a document to describe the release process for the slsa-github-generator
 Set up env variables:
 
 ```shell
-export GH_TOKEN=<PAT-token>
 export GITHUB_USERNAME="laurentsimon"
 # This is the existing slsa-verifier version used by the builder. (https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/actions/generate-builder/action.yml#L55)
-export VERIFIER_TAG="v1.3.2"
+export VERIFIER_TAG="v2.0.1"
 export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
 # Release tag of the builder we want to release. Release Candidates end with "-rc.#"
-export BUILDER_TAG="v1.2.2-rc.0"
+export BUILDER_TAG="v1.5.0-rc.0"
 # Branch name for our test
 export BUILDER_REF="release/bad-verifier-$BUILDER_TAG"
 export BUILDER_REPOSITORY="$GITHUB_USERNAME/slsa-github-generator"
 export GH=/path/to/gh
+GH_TOKEN=$(${GH} auth token)
+export GH_TOKEN
 ```
 
 ## Release candidate

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,11 +66,17 @@ Create a new tag for the Release Candidate via [slsa-framework/slsa-github-gener
 
 Release candidates should include a suffix indicating the release candidate number of the form `-rc.#` where `#` is a number starting from `0`.
 
-Set the title to `$BUILDER_TAG`.
+1. Set the title to `$BUILDER_TAG`
+1. Add the following description.
 
-Tick the `This is a pre-release` option.
+   ```
+   **This is an un-finalized pre-release.**
 
-Click `Publish release`.
+   See the [CHANGELOG](./CHANGELOG.md) for details.
+   ```
+
+1. Tick the `This is a pre-release` option.
+1. Click `Publish release`.
 
 This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Cancel this in the [UI](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml).
 
@@ -310,6 +316,10 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 
    If it does not, delete the release, fix the bug and re-start the release process at the top of this page.
 
+### Finalize release candidate.
+
+Remove the "This is an un-finalized pre-release." note from the release description.
+
 ### Code Freeze
 
 Code freeze the repository for 1-2 days.
@@ -331,11 +341,17 @@ export BUILDER_TAG="vX.Y.Z"
 Create a new tag for the final release via [slsa-framework/slsa-github-generator/releases/new](https://github.com/slsa-framework/slsa-github-generator/releases/new). The tag _MUST_ be a "canonical" [semantic version](https://semver.org/) without metadata (`$BUILDER_TAG`). Shorter versions are not accepted by the builder's
 and verifier's code.
 
-Set the title to `$BUILDER_TAG`.
+1. Set the title to `$BUILDER_TAG`
+1. Add the following description.
 
-Tick the `This is a pre-release` option.
+   ```
+   **This is an un-finalized release.**
 
-Click `Publish release`.
+   See the [CHANGELOG](./CHANGELOG.md) for details.
+   ```
+
+1. Tick the `This is a pre-release` option.
+1. Click `Publish release`.
 
 This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Cancel this in the [UI](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml).
 
@@ -408,7 +424,8 @@ For each of the GHA builders, you will need to:
 
 ### Finish the release.
 
-Un-tick the `This is a pre-release` option.
+1. Remove the "This is an un-finalized release." note from the release description.
+1. Un-tick the `This is a pre-release` option.
 
 ### Update the starter workflows
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ This is a document to describe the release process for the slsa-github-generator
 
 - [Prerequisites](#prerequisites)
 - [Release candidate](#release-candidate)
+  - [Update CHANGELOG](#update-changelog)
   - [RC tagging](#rc-tagging)
   - [Verify RC version references](#verify-rc-version-references)
   - [Adversarial verifier tests](#adversarial-verifier-tests)
@@ -23,6 +24,7 @@ This is a document to describe the release process for the slsa-github-generator
   - [Finalize release candidate.](#finalize-release-candidate)
   - [Code Freeze](#code-freeze)
 - [Finalize release](#finalize-release)
+  - [Update CHANGELOG](#update-changelog-1)
   - [Release tagging](#release-tagging)
   - [Verify final version references](#verify-final-version-references)
   - [Final adversarial tests](#final-adversarial-tests)
@@ -61,6 +63,10 @@ export GH_TOKEN
 The first step in creating a release is to create a release candidate. Release candidates exercise the release and testing process.
 
 If any tests fail for a release candidate you can address the issues and create a new release candidate after incrementing the release candidate number.
+
+### Update CHANGELOG
+
+Finalize the [CHANGELOG](./CHANGELOG.md) entry for the release candidate noting changes since the last release or release candidate.
 
 ### RC tagging
 
@@ -337,6 +343,10 @@ Update your `BUILDER_TAG` environment variable to the final release tag.
 ```shell
 export BUILDER_TAG="vX.Y.Z"
 ```
+
+### Update CHANGELOG
+
+Finalize the [CHANGELOG](./CHANGELOG.md) entry for the release candidate noting changes since the last major release (not including release candidates).
 
 ### Release tagging
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -385,23 +385,29 @@ The next step is to update the verifier's GitHub Actions e2e tests. There are Gi
 
 For each of the GHA builders, you will need to:
 
-1. Generate binaries and provenance in [example-package](https://github.com/slsa-framework/example-package) using the GHA action builder. These require using the updated builders, so validate that the workflows you use below are pinned at `$BUILDER_TAG`.
+1. Generate binaries and provenance in [example-package](https://github.com/slsa-framework/example-package) using the GHA action builder.
 
-You will need the following trigger types:
+   These require using the updated builders, so the first step is to update [verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml) to reference actions at `$BUILDER_TAG`.
 
-- A workflow dispatch event.
-- A tag of the form `vX.Y.Z`.
-- Tags of the form `vX` and `vX.Y`.
+   For example:
 
-To do this, trigger the [verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml) workflow. This will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on the following fixed release tags.
+   ```yaml
+   uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@$BUILDER_TAG
+   ```
 
-- [v14](https://github.com/slsa-framework/example-package/releases/tag/v14)
-- [v14.2](https://github.com/slsa-framework/example-package/releases/tag/v14.2)
-- [v13.0.30](https://github.com/slsa-framework/example-package/releases/tag/v13.0.30)
+   Next run the [verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml](https://github.com/slsa-framework/example-package/actions/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml). This will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on the following fixed release tags.
 
-Wait for the runs to complete and download the uploaded artifacts of each of the created releases.
+   - [v14](https://github.com/slsa-framework/example-package/releases/tag/v14)
+   - [v14.2](https://github.com/slsa-framework/example-package/releases/tag/v14.2)
+   - [v13.0.30](https://github.com/slsa-framework/example-package/releases/tag/v13.0.30)
+
+   Wait for the runs to complete and download the uploaded artifacts of each of the created releases.
 
 2. Move these files to `./cli/slsa-verifier/testdata/gha_$BUILDER_TYPE/$BUILDER_TAG/`. Send a pull request to merge the changes into the verifier's repository. The pre-submits will validate that the verifier is able to verify provenance from the `$BUILDER_TAG` builder.
+
+### Finish the release.
+
+Un-tick the `This is a pre-release` option.
 
 ### Update the starter workflows
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,37 @@
 # How to cut a release
 
-This is a document to describe the release process for the Go builder. Since all builders are in this repository, we will expand this doc to cover other builders in the future.
+This is a document to describe the release process for the slsa-github-generator repository.
 
 ---
 
+<!-- markdown-toc --bullets="-" -i RELEASE.md -->
+
+<!-- toc -->
+
 - [Prerequisites](#prerequisites)
-- [Tagging](#tagging)
-- [Verify version references](#verify-version-references)
-- [Pre-release Tests](#pre-release-tests)
-- [Post-release tests](#post-release-tests)
-- [Code Freeze](#code-freeze)
-- [Update Verifier](#update-verifier)
+- [Release candidate](#release-candidate)
+  - [RC tagging](#rc-tagging)
+  - [Verify RC version references](#verify-rc-version-references)
+  - [Adversarial verifier tests](#adversarial-verifier-tests)
+    - [Go builder verifier test](#go-builder-verifier-test)
+    - [Generic generator verifier test](#generic-generator-verifier-test)
+    - [Container generator verifier test](#container-generator-verifier-test)
+  - [Adversarial builder tests](#adversarial-builder-tests)
+    - [Adversarial Go builder](#adversarial-go-builder)
+    - [Adversarial generic generator](#adversarial-generic-generator)
+    - [Adversarial container generator](#adversarial-container-generator)
+  - [Code Freeze](#code-freeze)
 - [Finalize release](#finalize-release)
-- [Announce](#announce)
+  - [Release tagging](#release-tagging)
+  - [Verify final version references](#verify-final-version-references)
+  - [Final adversarial tests](#final-adversarial-tests)
+  - [Reference Actions at main](#reference-actions-at-main)
+  - [Update documentation](#update-documentation)
+  - [Update verifier](#update-verifier)
+  - [Update the starter workflows](#update-the-starter-workflows)
+  - [Announce](#announce)
+
+<!-- tocstop -->
 
 ---
 
@@ -26,18 +45,25 @@ export GITHUB_USERNAME="laurentsimon"
 # This is the existing slsa-verifier version used by the builder. (https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/actions/generate-builder/action.yml#L55)
 export VERIFIER_TAG="v1.3.2"
 export VERIFIER_REPOSITORY="$GITHUB_USERNAME/slsa-verifier"
-# Release tag of the builder we want to release
-export BUILDER_TAG="v1.2.2"
+# Release tag of the builder we want to release. Release Candidates end with "-rc.#"
+export BUILDER_TAG="v1.2.2-rc.0"
 # Branch name for our test
 export BUILDER_REF="release/bad-verifier-$BUILDER_TAG"
 export BUILDER_REPOSITORY="$GITHUB_USERNAME/slsa-github-generator"
 export GH=/path/to/gh
 ```
 
-## Tagging
+## Release candidate
 
-Create a new tag for the official generator via [slsa-framework/slsa-github-generator/releases/new](https://github.com/slsa-framework/slsa-github-generator/releases/new).
-The tag _MUST_ be a "canonical" semantic version without metadata (`$BUILDER_TAG`). Shorter versions are not accepted by the builder's and verifier's code.
+The first step in creating a release is to create a release candidate. Release candidates exercise the release and testing process.
+
+If any tests fail for a release candidate you can address the issues and create a new release candidate after incrementing the release candidate number.
+
+### RC tagging
+
+Create a new tag for the Release Candidate via [slsa-framework/slsa-github-generator/releases/new](https://github.com/slsa-framework/slsa-github-generator/releases/new). The tag _MUST_ be a "canonical" [semantic version](https://semver.org/) without metadata (`$BUILDER_TAG`). Shorter versions are not accepted by the builder's and verifier's code.
+
+Release candidates should include a suffix indicating the release candidate number of the form `-rc.#` where `#` is a number starting from `0`.
 
 Set the title to `$BUILDER_TAG`.
 
@@ -47,7 +73,7 @@ Click `Publish release`.
 
 This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Cancel this in the [UI](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml).
 
-## Verify version references
+### Verify RC version references
 
 Update version references with the following command:
 
@@ -57,7 +83,7 @@ find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: 
 
 Send a PR with this update and add `#label:release ${BUILDER_TAG}` in the PR description.
 
-Once the PR is merged, update the tag to point to HEAD.
+Once the PR is merged, immediately update the tag to point to HEAD.
 
 ```shell
 git tag $BUILDER_TAG -f
@@ -66,7 +92,7 @@ git push origin $BUILDER_TAG -f
 
 This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds and that the release assets are updated.
 
-## Pre-release tests
+### Adversarial verifier tests
 
 There is one integration test we cannot easily test "live", so we need to simulate it by changing the code: malicious verifier binary in assets. We want to be sure the builder fails if the verifier's binary is tampered with. For this:
 
@@ -114,7 +140,7 @@ There is one integration test we cannot easily test "live", so we need to simula
 
    This will trigger a workflow release, let it complete and generate the release assets.
 
-### Go builder
+#### Go builder verifier test
 
 1. Edit the file [slsa-framework/example-package/.github/workflows/e2e.go.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/e2e.go.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml) by using `$BUILDER_REPOSITORY` and `$BUILDER_TAG`:
 
@@ -130,7 +156,7 @@ There is one integration test we cannot easily test "live", so we need to simula
    Error: Process completed with exit code 4.
    ```
 
-### Generic generator
+#### Generic generator verifier test
 
 1. Edit the file [slsa-framework/example-package/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml) by using `$BUILDER_REPOSITORY` and `$BUILDER_TAG`:
 
@@ -146,7 +172,7 @@ There is one integration test we cannot easily test "live", so we need to simula
    Error: Process completed with exit code 4.
    ```
 
-### Container generator
+#### Container generator verifier test
 
 1. Edit the file [slsa-framework/example-package/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml) by using `$BUILDER_REPOSITORY` and `$BUILDER_TAG`:
 
@@ -162,11 +188,11 @@ There is one integration test we cannot easily test "live", so we need to simula
    Error: Process completed with exit code 4.
    ```
 
-## Post-release tests
+### Adversarial builder tests
 
 End-to-end tests run daily in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/), and contain adversarial tests (developer tampers with the artifacts used by the builders). All these adversarial tests compile the builder from source (`compile-builder: true`). But we need to verify that the builder detects malicious builder's binary when `compile-builder: false` (default).
 
-### Go builder
+#### Adversarial Go builder
 
 1. Make sure you have downloaded the `$BUILDER_TAG` builder's binary locally `slsa-builder-go-linux-amd64`, either via the web UI or via:
 
@@ -205,7 +231,7 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 
    If it does not, delete the release, fix the bug and re-start the release process at the top of this page.
 
-### Generic generator
+#### Adversarial generic generator
 
 1. Make sure you have downloaded the `$BUILDER_TAG` builder's binary locally `slsa-generator-generic-linux-amd64`, either via the web UI or via:
 
@@ -244,7 +270,7 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 
    If it does not, delete the release, fix the bug and re-start the release process at the top of this page.
 
-### Container generator
+#### Adversarial container generator
 
 1. Make sure you have downloaded the `$BUILDER_TAG` builder's binary locally `slsa-generator-container-linux-amd64`, either via the web UI or via:
 
@@ -283,17 +309,79 @@ End-to-end tests run daily in [github.com/slsa-framework/example-package/.github
 
    If it does not, delete the release, fix the bug and re-start the release process at the top of this page.
 
-## Code Freeze
+### Code Freeze
 
 Code freeze the repository for 1-2 days.
 
 After the code freeze, verify all the e2e tests in [github.com/slsa-framework/example-package/.github/workflows/](github.com/slsa-framework/example-package/.github/workflows/) are passing. (They run daily).
 
-## Update verifier
+## Finalize release
+
+Once the code release is complete you may create a final release.
+
+Update your `BUILDER_TAG` environment variable to the final release tag.
+
+```shell
+export BUILDER_TAG="vX.Y.Z"
+```
+
+### Release tagging
+
+Create a new tag for the final release via [slsa-framework/slsa-github-generator/releases/new](https://github.com/slsa-framework/slsa-github-generator/releases/new). The tag _MUST_ be a "canonical" [semantic version](https://semver.org/) without metadata (`$BUILDER_TAG`). Shorter versions are not accepted by the builder's
+and verifier's code.
+
+Set the title to `$BUILDER_TAG`.
+
+Tick the `This is a pre-release` option.
+
+Click `Publish release`.
+
+This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Cancel this in the [UI](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml).
+
+### Verify final version references
+
+Update version references with the following command:
+
+```shell
+find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@\(main\|v[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?\)/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@$BUILDER_TAG/"
+```
+
+Send a PR with this update and add `#label:release ${BUILDER_TAG}` in the PR description.
+
+Once the PR is merged, immediately update the tag to point to HEAD.
+
+```shell
+git tag $BUILDER_TAG -f
+git push origin $BUILDER_TAG -f
+```
+
+This will trigger the [release workflow](https://github.com/slsa-framework/slsa-github-generator/actions/workflows/release.yml). Ensure this workflow succeeds and that the release assets are updated.
+
+### Final adversarial tests
+
+Re-run the [adversarial tests](#adversarial-tests) using the final `$BUILDER_TAG` for the release. If any tests fail you will need to delete the release and address the issues.
+
+### Reference Actions at main
+
+Send a PR to reference the internal Actions at `@main`. You can use:
+
+```shell
+find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@${BUILDER_TAG}/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@main/"
+```
+
+### Update documentation
+
+Send a PR to update the documentation to recommend using the new version:
+
+```shell
+find . -name '*.md' | xargs sed -i "s/slsa-framework\/slsa-github-generator\/\.github\/\(.*\)@v[0-9]\+\.[0-9]\+\.[0-9]\+/slsa-framework\/slsa-github-generator\/.github\/\1@${BUILDER_TAG}/"
+```
+
+### Update verifier
 
 The next step is to update the verifier's GitHub Actions e2e tests. There are GitHub actions Go and generic actions.
 
-<!-- TODO(https://github.com/slsa-framework/slsa-github-generator/issues/1110): Describe GHA generic container e2e tests. -->
+<!-- TODO(github.com/slsa-framework/slsa-github-generator/issues/1110): Describe GHA generic container e2e tests. -->
 
 For each of the GHA builders, you will need to:
 
@@ -305,40 +393,25 @@ You will need the following trigger types:
 - A tag of the form `vX.Y.Z`.
 - Tags of the form `vX` and `vX.Y`.
 
-To do this, trigger the following workflows, waiting for each to finish before starting the next. These will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on fixed tags.
+To do this, trigger the [verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml) workflow. This will dispatch the workflow and create provenance for the workflow dispatch event, and then trigger subsequent runs on the following fixed release tags.
 
-- [Go workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.go.workflow_dispatch.main.all.slsa3.yml)
-- [Generic workflow dispatch](https://github.com/slsa-framework/example-package/blob/main/.github/workflows/verifier-e2e.generic.workflow_dispatch.main.all.slsa3.yml).
+- [v14](https://github.com/slsa-framework/example-package/releases/tag/v14)
+- [v14.2](https://github.com/slsa-framework/example-package/releases/tag/v14.2)
+- [v13.0.30](https://github.com/slsa-framework/example-package/releases/tag/v13.0.30)
 
-Download the uploaded artifacts of each of these, labelling the workflow dispatch artifacts by `binary-linux-amd64-workflow_dispatch(.intoto.jsonl)` and the tags by `binary-linux-amd64-push-v$TAG(.intoto.jsonl)`.
+Wait for the runs to complete and download the uploaded artifacts of each of the created releases.
 
 2. Move these files to `./cli/slsa-verifier/testdata/gha_$BUILDER_TYPE/$BUILDER_TAG/`. Send a pull request to merge the changes into the verifier's repository. The pre-submits will validate that the verifier is able to verify provenance from the `$BUILDER_TAG` builder.
 
-## Finalize release
-
-Untick the `This is a pre-release` option.
-
-Update the documentation to recommend using the new version:
-
-```shell
-find . -name '*.md' | xargs sed -i "s/slsa-framework\/slsa-github-generator\/\.github\/\(.*\)@v[0-9]\+\.[0-9]\+\.[0-9]\+/slsa-framework\/slsa-github-generator\/.github\/\1@${BUILDER_TAG}/"
-```
-
-## Send a PR to reference Actions at main
-
-Send a PR to reference the internal Actions at `@main`. You can use:
-
-```shell
-find .github/workflows/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\.github\/actions\/\(.*\)@${BUILDER_TAG}/uses: slsa-framework\/slsa-github-generator\/.github\/actions\/\1@main/"
-```
-
-## Update the starter workflows
+### Update the starter workflows
 
 Update:
 
 1. [Go builder's workflow](https://github.com/actions/starter-workflows/blob/main/ci/go-ossf-slsa3-publish.yml)
 1. [Generic generator's workflow](https://github.com/actions/starter-workflows/blob/main/ci/generic-generator-ossf-slsa3-publish.yml)
 
-## Announce
+### Announce
 
 <!-- TODO(release): Provide details  -->
+
+Announce the release to users.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@ This is a document to describe the release process for the slsa-github-generator
     - [Adversarial Go builder](#adversarial-go-builder)
     - [Adversarial generic generator](#adversarial-generic-generator)
     - [Adversarial container generator](#adversarial-container-generator)
+  - [Finalize release candidate.](#finalize-release-candidate)
   - [Code Freeze](#code-freeze)
 - [Finalize release](#finalize-release)
   - [Release tagging](#release-tagging)
@@ -28,6 +29,7 @@ This is a document to describe the release process for the slsa-github-generator
   - [Reference Actions at main](#reference-actions-at-main)
   - [Update documentation](#update-documentation)
   - [Update verifier](#update-verifier)
+  - [Finish the release.](#finish-the-release)
   - [Update the starter workflows](#update-the-starter-workflows)
   - [Announce](#announce)
 


### PR DESCRIPTION
Fixes #1296 

Adds instructions to RELEASE.md for creating release candidates as part of the release process.

I will use this version of the instructions for the upcoming v1.5.0 release.

Signed-off-by: Ian Lewis <ianlewis@google.com>