### PR TITLE
fix: fix defer cleanup before error checking db

### DIFF
--- a/internal/builders/docker/commands.go
+++ b/internal/builders/docker/commands.go
@@ -78,9 +78,9 @@ func BuildCmd(check func(error)) *cobra.Command {
 			check(err)
 
 			db, err := builder.SetUpBuildState()
+			check(err)
 			// Remove any temporary files that were generated during the setup.
 			defer db.RepoInfo.Cleanup()
-			check(err)
 
 			artifacts, err := db.BuildArtifacts()
 			check(err)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This was introduced here https://github.com/slsa-framework/slsa-github-generator/pull/1388/commits/e6231cc2161b8924d56ae1abea0da49ce9a246fb but there is a cleanup function that is set before the error on `db` is checked, which gives a nilptr exception. 

Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1501

/review @rbehjati 