### PR TITLE
feat: Revert repository-username secret

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -28,8 +28,6 @@ defaults:
 on:
   workflow_call:
     secrets:
-      registry-username:
-        description: "Username to log into the container registry."
       registry-password:
         description: "Password to log in the container registry."
         required: true
@@ -44,6 +42,7 @@ on:
         type: string
       registry-username:
         description: "Username to log into the container registry."
+        required: true
         type: string
       compile-generator:
         description: "Build the generator from source. This increases build time by ~2m."
@@ -136,8 +135,7 @@ jobs:
         continue-on-error: true
         env:
           UNTRUSTED_IMAGE: "${{ inputs.image }}"
-          UNTRUSTED_INPUT_USERNAME: "${{ inputs.registry-username }}"
-          UNTRUSTED_SECRET_USERNAME: "${{ secrets.registry-username }}"
+          UNTRUSTED_USERNAME: "${{ inputs.registry-username }}"
           UNTRUSTED_PASSWORD: "${{ secrets.registry-password }}"
         run: |
           set -euo pipefail
@@ -148,19 +146,13 @@ jobs:
           # See: https://stackoverflow.com/questions/37861791/how-are-docker-image-names-parsed#37867949
           untrusted_registry="docker.io"
           # NOTE: Do not fail the script if grep does not match.
-          maybe_domain=$(echo "${UNTRUSTED_IMAGE}" | cut -f1 -d "/" | { grep -E "\.|:" || true; })
-          if [ "${maybe_domain}" != "" ]; then
-            untrusted_registry="${maybe_domain}"
+          maybe_domain=$(echo "$UNTRUSTED_IMAGE" | cut -f1 -d "/" | { grep -E "\.|:" || true; })
+          if [ "$maybe_domain" != "" ]; then
+            untrusted_registry="$maybe_domain"
           fi
 
-          username="${UNTRUSTED_SECRET_USERNAME:-${UNTRUSTED_INPUT_USERNAME}}"
-          if [ "${username}" == "" ]; then
-              echo "registry-username is required." >&2
-              exit 1
-          fi
-
-          echo "login to ${untrusted_registry}"
-          cosign login "${untrusted_registry}" -u "${username}" -p "${UNTRUSTED_PASSWORD}"
+          echo "login to $untrusted_registry"
+          cosign login "$untrusted_registry" -u "$UNTRUSTED_USERNAME" -p "$UNTRUSTED_PASSWORD"
 
       - name: Create and sign provenance
         id: sign-prov

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -207,17 +207,16 @@ Inputs:
 | -------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `image`              | yes      |         | The OCI image name. This must not include a tag or digest.                                                                                                                                                                      |
 | `digest`             | yes      |         | The OCI image digest. The image digest of the form '<algorithm>:<digest>' (e.g. 'sha256:abcdef...')                                                                                                                             |
-| `registry-username`  | no       |         | Username to log in the container registry. Either `registry-username` input or `registry-username` secret is required.                                                                                                          |
+| `registry-username`  | yes      |         | Username to log into the container registry.                                                                                                                                                                                    |
 | `compile-generator`  | false    | false   | Whether to build the generator from source. This increases build time by ~2m.                                                                                                                                                   |
 | `private-repository` | no       | false   | Set to true to opt-in to posting to the public transparency log. Will generate an error if false for private repositories. This input has no effect for public repositories. See [Private Repositories](#private-repositories). |
 | `continue-on-error`  | no       | false   | Set to true to ignore errors. This option is useful if you won't want a failure to fail your entire workflow.                                                                                                                   |
 
 Secrets:
 
-| Name                | Required | Description                                                                                                            |
-| ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `registry-username` | no       | Username to log in the container registry. Either `registry-username` input or `registry-username` secret is required. |
-| `registry-password` | yes      | Password to log in the container registry.                                                                             |
+| Name                | Required | Description                                |
+| ------------------- | -------- | ------------------------------------------ |
+| `registry-password` | yes      | Password to log in the container registry. |
 
 ### Workflow Outputs
 


### PR DESCRIPTION
Fixes #1347 

This rolls back the `repository-username` secret now that [support for configuration values](https://github.blog/changelog/2023-01-10-github-actions-support-for-configuration-variables-in-workflows/) was added to GitHub Actions. This feature was not released in any releases yet so backwards compatibility is not an issue.

This reverts commit 1ed3657976aadcbd9fe3aaf2117d315e0a934e97.

Signed-off-by: Ian Lewis <ianlewis@google.com>