### PR TITLE
fix: fix verify-token schedule

### DIFF
--- a/.github/workflows/e2e.verify-token.schedule.yml
+++ b/.github/workflows/e2e.verify-token.schedule.yml
@@ -39,7 +39,6 @@ jobs:
           VERIFIED_TOKEN: ${{ steps.verify.outputs.slsa-verified-token }}
           TOOL_REPOSITORY: ${{ steps.verify.outputs.tool-repository }}
           TOOL_REF: ${{ steps.verify.outputs.tool-ref }}
-          TOOL_URI: ${{ steps.verify.outputs.tool-uri }}
           PREDICATE: predicate.json
       - id: verify-mismatch-recipient
         uses: ./.github/actions/verify-token

--- a/.github/workflows/scripts/schedule.actions/verify-token.sh
+++ b/.github/workflows/scripts/schedule.actions/verify-token.sh
@@ -9,7 +9,6 @@ source "./.github/workflows/scripts/e2e-verify.common.sh"
 echo "VERIFIED_TOKEN: $VERIFIED_TOKEN"
 echo "TOOL_REPOSITORY: $TOOL_REPOSITORY"
 echo "TOOL_REF: $TOOL_REF"
-echo "TOOL_URI: $TOOL_URI"
 echo "PREDICATE: $PREDICATE"
 
 # Non-GitHub's information.
@@ -50,7 +49,6 @@ e2e_assert_eq "$GITHUB_REF_TYPE" "$ref_type"
 e2e_assert_eq "$GITHUB_ACTOR" "$actor"
 e2e_assert_eq "$TOOL_REPOSITORY" "$GITHUB_REPOSITORY"
 e2e_assert_eq "$TOOL_REF" "$GITHUB_REF"
-e2e_assert_eq "$TOOL_URI" "https://github.com/$GITHUB_REPOSITORY/.github/workflows/e2e.verify-token.schedule.yml@$GITHUB_REF"
 
 PREDICATE_CONTENT=$(<"$PREDICATE")
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1558

Tool-uri is no longer an output, but we do verify that the predicate builder is this tool uri in the script already.