### PR TITLE
fix: workflowPath in provenance is fully qualified

### DIFF
--- a/.github/workflows/scripts/e2e-utils.sh
+++ b/.github/workflows/scripts/e2e-utils.sh
@@ -8,6 +8,10 @@ e2e_this_file() {
     gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3
 }
 
+e2e_this_file_full_path() {
+    gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path'
+}
+
 e2e_verify_predicate_subject_name() {
     _e2e_verify_query "$1" "$2" '.subject[0].name'
 }

--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -68,7 +68,7 @@ e2e_verify_common_all_v1() {
 # $1: the predicate content
 e2e_verify_common_buildDefinition_v1() {
     # This does not include buildType since it is not common to all.
-    e2e_verify_predicate_v1_buildDefinition_externalParameters_workflowPath "$1" "$(e2e_this_file)"
+    e2e_verify_predicate_v1_buildDefinition_externalParameters_workflowPath "$1" "$(e2e_this_file_full_path)"
     e2e_verify_predicate_v1_buildDefinition_externalParameters_source "$1" "{\"artifact\":{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha1\":\"$GITHUB_SHA\"}}}"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "GITHUB_EVENT_NAME" "$GITHUB_EVENT_NAME"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "GITHUB_JOB" "$GITHUB_JOB"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

The run fails because the `workflowPath` should be fully qualified, and `e2e_this_file` only returns the basename.

cc @laurentsimon 