### PR TITLE
ci: fix check-dist upload on failure

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist
-          path: dist/
+          path: ${{ matrix.action }}/dist/
 
   # NOTE: needed for protected branch checks.
   check-dist:


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

The path requires the matrix's action path.

Checkout seems to support expansion:
https://github.com/actions/upload-artifact#environment-variables-and-tilde-expansion