### PR TITLE
fix: Add verify subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.4 // indirect
 	github.com/alibabacloud-go/cr-20160607 v1.0.1 // indirect
@@ -177,6 +178,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.1.2 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
@@ -191,6 +193,7 @@ require (
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/go-gitlab v0.73.1 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	github.com/zeebo/errs v1.3.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
+github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -363,6 +365,7 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -1134,6 +1137,7 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1220,6 +1224,8 @@ github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.13.0 h1:BWSJ/M+f+3nmdz9bxB+bWX28kkALN2ok11D0rSo8EJU=
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
+github.com/spiffe/go-spiffe/v2 v2.1.2 h1:nfNwopOP7q0qsWU6AUASqmbtYViwHA6vuHyAtqFJtNc=
+github.com/spiffe/go-spiffe/v2 v2.1.2/go.mod h1:cbQmFrxsOpbm5tWURAYip9ZK0dOSFeoFG3/5Ub9Hvy0=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -1311,6 +1317,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.1.0/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
+github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
+github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -18,7 +18,7 @@ command. The following is an example, which assumes you are running the code in
 ```bash
 go run *.go  dry-run \
   --build-config-path internal/builders/docker/testdata/config.toml \
-  --builder-image bash@sha256:9e2ba52487d \
+  --builder-image bash@sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9 \
   --git-commit-digest sha1:cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00 \
   --source-repo git+https://github.com/slsa-framework/slsa-github-generator \
   --build-definition-path bd.json \
@@ -47,4 +47,18 @@ go run *.go build \
 ```
 
 If the build is successful, this command will generate `subjects.json`
-containing a JSON-encoded list of generated artifacts and their SHA256 digests. It also writes all artifacts to the `output-folder`.
+containing a JSON-encoded list of generated artifacts and their SHA256 digests.
+It also writes all artifacts to the `output-folder`.
+
+## The `verify` command
+
+The `verify` subcommand takes the path to a SLSAv1.0 provenance and verifies it,
+by rebuilding the artifacts using the build definition in the provenance, and
+checking that the resulting artifacts have the same names and subjects as the
+ones in the provenance subject.
+
+Here is an example:
+
+```bash
+go run *.go verify --provenance-path testdata/slsa1-provenance.json
+```

--- a/internal/builders/docker/main.go
+++ b/internal/builders/docker/main.go
@@ -41,6 +41,7 @@ For more information on SLSA, visit https://slsa.dev`,
 	}
 	cmd.AddCommand(DryRunCmd(checkExit))
 	cmd.AddCommand(BuildCmd(checkExit))
+	cmd.AddCommand(VerifyCmd(checkExit))
 	return cmd
 }
 

--- a/internal/builders/docker/pkg/common.go
+++ b/internal/builders/docker/pkg/common.go
@@ -37,9 +37,9 @@ const (
 	CommandKey = "command"
 )
 
-// DockerBasedExternalParmaters is a representation of the top level inputs to a
+// DockerBasedExternalParameters is a representation of the top level inputs to a
 // docker-based build.
-type DockerBasedExternalParmaters struct {
+type DockerBasedExternalParameters struct {
 	// The source GitHub repo
 	Source slsa1.ArtifactReference `json:"source"`
 

--- a/internal/builders/docker/pkg/common_test.go
+++ b/internal/builders/docker/pkg/common_test.go
@@ -32,8 +32,8 @@ func Test_BuildDefinition(t *testing.T) {
 	}
 
 	wantSource := slsa1.ArtifactReference{
-		URI:    "git+https://github.com/project-oak/transparent-release",
-		Digest: map[string]string{"sha1": "9b5f98310dbbad675834474fa68c37d880687cb9"},
+		URI:    "git+https://github.com/slsa-framework/slsa-github-generator",
+		Digest: map[string]string{"sha1": "cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"},
 	}
 
 	wantBuilderImage := slsa1.ArtifactReference{
@@ -43,7 +43,7 @@ func Test_BuildDefinition(t *testing.T) {
 
 	want := &slsa1.ProvenanceBuildDefinition{
 		BuildType: "https://slsa.dev/container-based-build/v0.1?draft",
-		ExternalParameters: DockerBasedExternalParmaters{
+		ExternalParameters: DockerBasedExternalParameters{
 			Source:       wantSource,
 			BuilderImage: wantBuilderImage,
 			ConfigPath:   "internal/builders/docker/testdata/config.toml",
@@ -89,7 +89,7 @@ func loadBuildDefinitionFromFile(path string) (*slsa1.ProvenanceBuildDefinition,
 		return nil, fmt.Errorf("could not marshal the external params in %q: %w", path, err)
 	}
 
-	var dockerEp DockerBasedExternalParmaters
+	var dockerEp DockerBasedExternalParameters
 	if err := json.Unmarshal(epBytes, &dockerEp); err != nil {
 		return nil, fmt.Errorf("could not unmarshal the JSON file in %q as a DockerBasedExternalParameters: %w", path, err)
 	}

--- a/internal/builders/docker/testdata/build-definition.json
+++ b/internal/builders/docker/testdata/build-definition.json
@@ -2,9 +2,9 @@
     "buildType": "https://slsa.dev/container-based-build/v0.1?draft",
     "externalParameters": {
         "source": {
-            "uri": "git+https://github.com/project-oak/transparent-release",
+            "uri": "git+https://github.com/slsa-framework/slsa-github-generator",
             "digest": {
-                "sha1": "9b5f98310dbbad675834474fa68c37d880687cb9"
+                "sha1": "cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"
             }
         },
         "builderImage": {
@@ -15,7 +15,11 @@
         },
         "buildConfig": {
             "artifactPath": "config.toml",
-            "command": ["cp","internal/builders/docker/testdata/config.toml","config.toml"]
+            "command": [
+                "cp",
+                "internal/builders/docker/testdata/config.toml",
+                "config.toml"
+            ]
         },
         "configPath": "internal/builders/docker/testdata/config.toml"
     }

--- a/internal/builders/docker/testdata/slsa1-provenance.json
+++ b/internal/builders/docker/testdata/slsa1-provenance.json
@@ -1,0 +1,40 @@
+{
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v1.0",
+    "subject": [
+        {
+            "name": "config.toml",
+            "digest": {
+                "sha256": "975a0582b8c9607f3f20a6b8cfef01b25823e68c5c3658e6e1ccaaced2a3255d"
+            }
+        }
+    ],
+    "predicate": {
+        "buildDefinition": {
+            "buildType": "https://slsa.dev/container-based-build/v0.1?draft",
+            "externalParameters": {
+                "source": {
+                    "uri": "git+https://github.com/slsa-framework/slsa-github-generator",
+                    "digest": {
+                        "sha1": "cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"
+                    }
+                },
+                "builderImage": {
+                    "uri": "bash@sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9",
+                    "digest": {
+                        "sha256": "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
+                    }
+                },
+                "configPath": "internal/builders/docker/testdata/config.toml",
+                "buildConfig": {
+                    "ArtifactPath": "config.toml",
+                    "Command": [
+                        "cp",
+                        "internal/builders/docker/testdata/config.toml",
+                        "config.toml"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1618 

Adds a `verify` subcommand as described in #1618. Fixes and updates the README and testdata used in the README and examples.

Signed-off-by: Razieh Behjati <razieh@google.com>