### PR TITLE
fix: fix workflow output in docker-based workflow

### DIFF
--- a/.github/actions/detect-workflow/README.md
+++ b/.github/actions/detect-workflow/README.md
@@ -63,9 +63,11 @@ jobs:
     env:
       REPO: "${{ steps.detect-workflow.outputs.repository }}"
       REF: "${{ steps.detect-workflow.outputs.ref }}"
+      WORKFLOW: "${{ steps.detect-workflow.outputs.workflow }}"
     run: |
       echo $REPO
       echo $REF
+      echo $WORKFLOW
 ```
 
 In the example above, `REPO` and `REF` will be equal to the repository and ref
@@ -73,7 +75,8 @@ from the user workflow's call to the reusable workflow.
 
 ## Outputs
 
-| Name         | Description                                                           |
-| ------------ | --------------------------------------------------------------------- |
-| `repository` | The repository of the reusable workflow (`{owner}/{repository name}`) |
-| `ref`        | The ref (branch, tag, or commit SHA) specified by the user.           |
+| Name         | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| `repository` | The repository of the reusable workflow (`{owner}/{repository name}`)          |
+| `ref`        | The ref (branch, tag, or commit SHA) specified by the user.                    |
+| `workflow`   | The workflow path, relative to the `repository` (`.github/workflows/test.yml`) |

--- a/.github/actions/detect-workflow/README.md
+++ b/.github/actions/detect-workflow/README.md
@@ -70,8 +70,9 @@ jobs:
       echo $WORKFLOW
 ```
 
-In the example above, `REPO` and `REF` will be equal to the repository and ref
-from the user workflow's call to the reusable workflow.
+In the example above, `REPO`, `WORKFLOW` and `REF` will be equal to the
+repository, workflow path, and ref from the user workflow's call to the
+reusable workflow.
 
 ## Outputs
 

--- a/.github/actions/detect-workflow/action.yml
+++ b/.github/actions/detect-workflow/action.yml
@@ -22,7 +22,7 @@ outputs:
     description: The current workflow reference
     value: ${{ steps.detect.outputs.ref }}
   workflow:
-    description: The fully qualified current job workflow ref, for example "https://github.com/org/repo/path/to/workflow@refs/heads/main"
+    description: The path to the workflow relative to the repository, for example ".github/workflows/example.yml"
     value: ${{ steps.detect.outputs.workflow }}
 runs:
   using: "docker"

--- a/.github/actions/detect-workflow/main.go
+++ b/.github/actions/detect-workflow/main.go
@@ -158,6 +158,7 @@ func main() {
 	// Log to help troubleshooting.
 	fmt.Printf("repository:%s\n", repository)
 	fmt.Printf("ref:%s\n", ref)
+	fmt.Printf("workflow:%s\n", workflow)
 
 	// Output of the Action.
 	github.SetOutput("repository", repository)

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -102,6 +102,7 @@ jobs:
     outputs:
       repository: ${{ steps.detect.outputs.repository }}
       ref: ${{ steps.detect.outputs.ref }}
+      workflow: ${{ steps.detect.outputs.workflow }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed to detect the current reusable repository and ref.


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

I missed setting the `workflow` output in the job outputs. 

I didn't notice this, because during pre-submit detect-env doesn't catch `workflow` anyway.

Also updates the `action.yml` and `README.md`, because `workflow` was just the workflow path.