### PR TITLE
test: add testing for docker based predicate creation

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -357,8 +357,8 @@ jobs:
         with:
           build-definition: "${{ needs.generate-build-definition.outputs.build-definition-name }}"
           binary-sha256: "${{ needs.generate-builder.outputs.builder-binary-sha256 }}"
-          binary-uri: "git+https://github.com/${{ needs.detect-env.outputs.repository }}@refs/heads/${{ needs.detect-env.outputs.ref }}"
-          builder-id: "https://github.com/${{ needs.detect-env.outputs.repository }}/${{ needs.detect-env.outputs.workflow }}@refs/heads/${{ needs.detect-env.outputs.ref }}"
+          binary-uri: "git+https://github.com/${{ needs.detect-env.outputs.repository }}@${{ needs.detect-env.outputs.ref }}"
+          builder-id: "https://github.com/${{ needs.detect-env.outputs.repository }}/${{ needs.detect-env.outputs.workflow }}@${{ needs.detect-env.outputs.ref }}"
           output-file: "predicate-${{ needs.rng.outputs.value }}"
 
       ###################################################################

--- a/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
@@ -1,0 +1,42 @@
+name: schedule create-docker_based-predicate
+
+# This workflow requires `id-token: write` permissions to determine the
+# builder identity. 
+
+on:
+  # Daily run.
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  ISSUE_REPOSITORY: ${{ github.repository }}
+
+jobs:
+  predicate:
+    outputs:
+      repository: ${{ steps.detect.outputs.repository }}
+      ref: ${{ steps.detect.outputs.ref }}
+      workflow: ${{ steps.detect.outputs.workflow }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to detect the current reusable repository and ref.
+    steps:
+      - name: Detect the builder ref
+        id: detect
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@main
+      - name: Create predicate
+        id: predicate
+        uses: ./.github/actions/create-docker_based-predicate
+        with:
+          build-definition: "internal/builders/docker/testdata/build-definition.json"
+          binary-sha256: "46b3ce0fbb2998880c5518225b41ddf49fc0850b9b9a25e1ac944bc587c03ea7"
+          binary-uri: "git+https://github.com/${{ needs.detect-env.outputs.repository }}@${{ needs.detect-env.outputs.ref }}"
+          builder-id: "https://github.com/${{ needs.detect-env.outputs.repository }}/${{ needs.detect-env.outputs.workflow }}@${{ needs.detect-env.outputs.ref }}"
+          output-file: "predicate.json"
+      - run: ./.github/workflows/scripts/schedule.actions/verify-docker_based-predicate.sh
+        env:
+          PREDICATE: predicate.json

--- a/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
@@ -40,3 +40,32 @@ jobs:
       - run: ./.github/workflows/scripts/schedule.actions/verify-docker_based-predicate.sh
         env:
           PREDICATE: predicate.json
+
+  if-succeed:
+    needs: [sign-attestations]
+    runs-on: ubuntu-latest
+    # We use `== 'failure'` instead of ` != 'success'` because we want to ignore skipped jobs, if there are any.
+    if: github.event_name != 'workflow_dispatch' && needs.sign-attestations.result != 'failure'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: slsa-framework/example-package
+          ref: main
+      - run: ./.github/workflows/scripts/e2e-report-success.sh
+
+  if-failed:
+    needs: [sign-attestations]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name != 'workflow_dispatch' && needs.sign-attestations.result == 'failure'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: slsa-framework/example-package
+          ref: main
+      - run: ./.github/workflows/scripts/e2e-report-failure.sh

--- a/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
@@ -1,7 +1,7 @@
 name: schedule create-docker_based-predicate
 
 # This workflow requires `id-token: write` permissions to determine the
-# builder identity. 
+# builder identity.
 
 on:
   # Daily run.

--- a/.github/workflows/scripts/e2e-utils.sh
+++ b/.github/workflows/scripts/e2e-utils.sh
@@ -92,6 +92,10 @@ e2e_verify_predicate_v1_buildDefinition_buildType() {
     _e2e_verify_query "$1" "$2" '.buildDefinition.buildType'
 }
 
+e2e_verify_predicate_v1_buildDefinition_resolvedDependencies() {
+    _e2e_verify_query "$1" "$2" '.buildDefinition.resolvedDependencies'
+}
+
 e2e_verify_predicate_v1_buildDefinition_systemParameters() {
     _e2e_verify_query "$1" "$3" '.buildDefinition.systemParameters.'"$2"
 }

--- a/.github/workflows/scripts/schedule.actions/verify-docker_based-predicate.sh
+++ b/.github/workflows/scripts/schedule.actions/verify-docker_based-predicate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "./.github/workflows/scripts/e2e-assert.sh"
+source "./.github/workflows/scripts/e2e-verify.common.sh"
+
+echo "PREDICATE: $PREDICATE"
+PREDICATE_CONTENT=$(<"$PREDICATE")
+echo "PREDICATE_CONTENT: $PREDICATE_CONTENT"
+
+# Verify common predicate fields.
+e2e_verify_common_all_v1  "$PREDICATE_CONTENT"
+e2e_verify_predicate_v1_buildDefinition_buildType "$PREDICATE_CONTENT" "https://slsa.dev/container-based-build/v0.1?draft"
+e2e_verify_predicate_v1_runDetails_builder_id "$PREDICATE_CONTENT" "https://github.com/$GITHUB_REPOSITORY/.github/workflows/e2e.create-docker_based-predicate.schedule.yml@$GITHUB_REF"
+
+# Verify resolved dependencies.
+e2e_verify_predicate_v1_buildDefinition_resolvedDependencies "$PREDICATE_CONTENT" "[{\"uri\": \"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\": {\"sha256\": \"46b3ce0fbb2998880c5518225b41ddf49fc0850b9b9a25e1ac944bc587c03ea7\"}}]"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

* Adds a schedule test for the `create-docker_based-predicate` action that exercises the builder ID option using detect-env's workflow. During pull request, we cannot detect the current reusable workflow path the caller invokes. 
* Fixed a repeated string issue in the action.