### PR TITLE
feat: add source ref to the docker build definition

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -211,13 +211,13 @@ jobs:
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}"
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -205,7 +205,7 @@ jobs:
           set -euo pipefail
 
           REF="@${GITHUB_REF}"
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             REF=""
           fi
 
@@ -285,7 +285,7 @@ jobs:
           set -euo pipefail
 
           REF="@${GITHUB_REF}"
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             REF=""
           fi
 

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -204,6 +204,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          REF="@${GITHUB_REF}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            REF=""
+          fi
+
           # Note: this outputs information about resolved arguments, etc.
           # the values are trusted because the compiler is not invoked.
           echo "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
@@ -211,13 +216,13 @@ jobs:
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}"
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 
@@ -279,19 +284,24 @@ jobs:
         run: |
           set -euo pipefail
 
+          REF="@${GITHUB_REF}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            REF=""
+          fi
+
           # Note: this outputs information about resolved arguments, etc.
           # the values are trusted because the compiler is not invoked.
           echo "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
             --subjects-path subjects.json
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
             --subjects-path subjects.json
 
           cat <<EOF >DATA

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -211,13 +211,13 @@ jobs:
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}"
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}"
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 
@@ -285,13 +285,13 @@ jobs:
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}" \
             --subjects-path subjects.json
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}" \
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}@{GITHUB_REF}" \
             --subjects-path subjects.json
 
           cat <<EOF >DATA

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -327,7 +327,8 @@ func (c *GitClient) verifyOrFetchRepo() error {
 func (c *GitClient) verifyRefAndCommit() (bool, error) {
 	checkCmds := []*exec.Cmd{exec.Command("git", "rev-parse", "--verify", "HEAD")}
 	if c.sourceRef != nil {
-		checkCmds = append(checkCmds, exec.Command("git", "show-ref", "--hash", "--verify", *c.sourceRef))
+		sourceRef := *c.sourceRef
+		checkCmds = append(checkCmds, exec.Command("git", "show-ref", "--hash", "--verify", sourceRef))
 	}
 
 	for _, cmd := range checkCmds {

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -232,6 +232,7 @@ func runDockerRun(db *DockerBuild) error {
 // Git repository.
 type GitClient struct {
 	sourceRepo    *string
+	sourceRef     *string
 	sourceDigest  *Digest
 	checkoutInfo  *RepoCheckoutInfo
 	logFiles      []string
@@ -258,8 +259,23 @@ func newGitClient(config *DockerBuildConfig, depth int) (*GitClient, error) {
 		return nil, fmt.Errorf("unsupported scheme: %v", parsed.Scheme)
 	}
 
+	// Retrieve the ref if a tag is added to the repository.
+	var sourceRef *string
+	refParts := strings.Split(repo, "@")
+	switch len(refParts) {
+	case 2:
+		// A source reference was provided.
+		sourceRef = &refParts[1]
+		repo = strings.TrimSuffix(repo, "@"+refParts[1])
+	case 1:
+		// No source reference was provided.
+	default:
+		return nil, fmt.Errorf("invalid source repository format: %s", repo)
+	}
+
 	return &GitClient{
 		sourceRepo:    &repo,
+		sourceRef:     sourceRef,
 		sourceDigest:  &config.SourceDigest,
 		forceCheckout: config.ForceCheckout,
 		depth:         depth,
@@ -291,7 +307,7 @@ func (c *GitClient) verifyOrFetchRepo() error {
 	if c.sourceDigest.Alg != "sha1" {
 		return fmt.Errorf("git commit digest must be a sha1 digest")
 	}
-	repoIsCheckedOut, err := c.verifyCommit()
+	repoIsCheckedOut, err := c.verifyRefAndCommit()
 	if err != nil && !c.forceCheckout {
 		return err
 	}
@@ -303,21 +319,29 @@ func (c *GitClient) verifyOrFetchRepo() error {
 	return nil
 }
 
-// verifyCommit checks that the current working directory is the root of a Git
-// repository at the given commit hash. Returns an error if the working
-// directory is a Git repository at a different commit.
-func (c *GitClient) verifyCommit() (bool, error) {
-	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
-	lastCommitIDBytes, err := cmd.Output()
-	if err != nil {
-		// The current working directory is not a git repo.
-		return false, nil
+// verifyRefAndCommit checks that the current working directory is the root of a Git
+// repository at the given commit hash. If a source ref is also specified, verifies
+// that the ref resolves to the given commit hash.
+// Returns an error if the working directory is a Git repository at a different commit
+// or ref.
+func (c *GitClient) verifyRefAndCommit() (bool, error) {
+	checkCmds := []*exec.Cmd{exec.Command("git", "rev-parse", "--verify", "HEAD")}
+	if c.sourceRef != nil {
+		checkCmds = append(checkCmds, exec.Command("git", "show-ref", "--hash", "--verify", *c.sourceRef))
 	}
-	lastCommitID := strings.TrimSpace(string(lastCommitIDBytes))
 
-	if lastCommitID != c.sourceDigest.Value {
-		return false, errors.Errorf(&errGitCommitMismatch{},
-			"the repo is already checked out at a different commit (%q)", lastCommitID)
+	for _, cmd := range checkCmds {
+		lastCommitIDBytes, err := cmd.Output()
+		if err != nil {
+			// The current working directory is not a git repo.
+			return false, nil
+		}
+		lastCommitID := strings.TrimSpace(string(lastCommitIDBytes))
+
+		if lastCommitID != c.sourceDigest.Value {
+			return false, errors.Errorf(&errGitCommitMismatch{},
+				"the repo is already checked out at a different commit (%q)", lastCommitID)
+		}
 	}
 
 	return true, nil
@@ -439,6 +463,11 @@ func (c *GitClient) checkoutGitCommit() error {
 	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("failed to complete the command: %v; see %q for logs, and %q for errors",
 			err, files[0], files[1])
+	}
+
+	ok, err := c.verifyRefAndCommit()
+	if err != nil || !ok {
+		return fmt.Errorf("failed to verify ref and commit: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

* Adds the option to specify a a source reference to the docker build definition, allowing the build definition source artifact to include the full URI with ref. The builder verifies that the ref matches the `git-commit-digest` specified.
```
{
  "buildType": "https://slsa.dev/container-based-build/v0.1?draft",
  "externalParameters": {
    "source": {
      "uri": "git+https://github.com/slsa-framework/slsa-github-generator@refs/heads/main",
      "digest": {
        "sha1": "e4cf1c15850a03ee3dc5a82159443513a5f31610"
      }
    },
    "builderImage": {
      "uri": "bash@sha256:9e2ba52487d",
      "digest": {
        "sha256": "9e2ba52487d"
      }
    },
    "configPath": "internal/builders/docker/testdata/config.toml",
    "buildConfig": {
      "ArtifactPath": "config.toml",
      "Command": [
        "cp",
        "internal/builders/docker/testdata/config.toml",
        "config.toml"
      ]
    }
  }
}
```