### PR TITLE
feat: add workflow outputs to docker-based workflow

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -25,8 +25,6 @@ env:
   BUILDER_DIR: internal/builders/docker # Source directory if we compile the builder.
   # SLSA outputs folder.
   OUTPUT_FOLDER: slsa-outputs
-  # Build outputs folder.
-  BUILD_OUTPUTS_FOLDER: build-outputs
 
 
 defaults:
@@ -88,6 +86,13 @@ on:
         # TODO: Secrets and Authentication options for the builder-image.
         #      * registry-username
         #      * registry-password
+    outputs:
+      build-outputs-name:
+        description: "The name of the folder where the generated artifacts are uploaded to the artifact registry."
+        value: ${{ jobs.build.outputs.build-outputs-name }}
+      provenance-name:
+        description: "The artifact name of the signed provenance. (A file with the intoto.sigstore extension)."
+        value: ${{ jobs.provenance.outputs.provenance-name }}
 
 jobs:
   rng:
@@ -249,6 +254,8 @@ jobs:
       slsa-outputs-name: ${{ steps.build.outputs.slsa-outputs-name }}
       # The digest of the SLSA subject outputs file for secure download.
       slsa-outputs-sha256: ${{ steps.upload.outputs.sha256 }}
+      # The build outputs
+      build-outputs-name: ${{ steps.build.outputs.build-outputs-name }}
     needs: [rng, detect-env, generate-builder]
     steps:
       - name: Checkout builder repository
@@ -323,8 +330,9 @@ jobs:
 
           cat DATA > output-template.json
 
-          jq --argjson subjects "$(<subjects.json)" '.attestations[0].subjects += $subjects' output-template.json > "${GITHUB_WORKSPACE}"/slsa-outputs.json
-          echo "slsa-outputs-name=slsa-outputs.json" >> $GITHUB_OUTPUT
+          jq --argjson subjects "$(<subjects.json)" '.attestations[0].subjects += $subjects' output-template.json > "${GITHUB_WORKSPACE}"/slsa-layout.json
+          echo "slsa-outputs-name=slsa-layout.json" >> $GITHUB_OUTPUT
+          echo "build-outputs-name=build-outputs-${RNG}" >> $GITHUB_OUTPUT
 
       - name: Upload the SLSA outputs file
         id: upload
@@ -334,10 +342,12 @@ jobs:
           path: "${{ steps.build.outputs.slsa-outputs-name }}"
 
       - name: Upload output artifacts
+        # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/1655): Use a
+        # secure upload or verify this against the SLSA layout file.
         id: upload-artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: ${{ env.BUILD_OUTPUTS_FOLDER }}
+          name: ${{ steps.build.outputs.build-outputs-name }}
           path: /tmp/build-outputs-${{ needs.rng.outputs.value }}
           if-no-files-found: error
 
@@ -354,7 +364,7 @@ jobs:
       contents: read  # Needed to check out the repository.
       actions: read # Needed to read workflow info.
     outputs:
-      provenance: ${{ steps.sign.outputs.output-name }}
+      provenance-name: "${{ env.OUTPUT_FOLDER }}-${{ needs.rng.outputs.value }}"
     steps:
       - name: Checkout builder repository
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
@@ -422,13 +432,13 @@ jobs:
         uses: ./__BUILDER_CHECKOUT_DIR__/.github/actions/sign-attestations
         with:
           attestations: "attestations-${{ needs.rng.outputs.value }}"
-          output-folder: "${{ env.OUTPUT_FOLDER }}"
+          output-folder: "${{ env.OUTPUT_FOLDER }}-${{ needs.rng.outputs.value }}"
 
       - name: Upload the signed attestations
         id: upload
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: "${{ env.OUTPUT_FOLDER }}"
-          path: "${{ env.OUTPUT_FOLDER }}"
+          name: "${{ env.OUTPUT_FOLDER }}-${{ needs.rng.outputs.value }}"
+          path: "${{ env.OUTPUT_FOLDER }}-${{ needs.rng.outputs.value }}"
           if-no-files-found: error


### PR DESCRIPTION
This adds two outputs to the docker-based workflow, `provenance-name` and `build-outputs-name` to store the generated provenance and generated build artifacts.

This allows users to consume these at later steps.

Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1500