### PR TITLE
fix: fix one more verify-token script check

### DIFF
--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -68,7 +68,7 @@ e2e_verify_common_all_v1() {
 # $1: the predicate content
 e2e_verify_common_buildDefinition_v1() {
     # This does not include buildType since it is not common to all.
-    e2e_verify_predicate_v1_buildDefinition_externalParameters_workflowPath "$1" "$(e2e_this_file_full_path)"
+    e2e_verify_predicate_v1_buildDefinition_externalParameters_workflow_path "$1" "$(e2e_this_file_full_path)"
     e2e_verify_predicate_v1_buildDefinition_externalParameters_source "$1" "{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha1\":\"$GITHUB_SHA\"}}"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "GITHUB_EVENT_NAME" "$GITHUB_EVENT_NAME"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "GITHUB_REF" "$GITHUB_REF"


### PR DESCRIPTION
I'm starting to think it would be good to run this during pre-submit at some point...

I can't think of the best way beyond a bunch of fakes that are just as hard to maintain