### PR TITLE
feat: add a provenance-name input option to the docker builder

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -68,19 +68,19 @@ on:
         required: false
         type: boolean
         default: false
-        # TODO: Options for requesting and verifying provenance of builder image
-        # This will use slsa-verifier and slsa-verifier option.
-        #      * request-builder-verification
-
+      provenance-name:
+        description: The artifact name of the signed provenance. The file must have the .intoto extension. Defaults to <filename>.intoto for single artifact or multiple.intoto.jsonl for multiple artifacts.
+        required: false
+        type: string
         # TODO: Secrets and Authentication options for the builder-image.
         #      * registry-username
         #      * registry-password
     outputs:
       build-outputs-name:
-        description: "The name of the folder where the generated artifacts are uploaded to the artifact registry."
+        description: "The name of the artifact where the generated artifacts are uploaded to the artifact registry."
         value: ${{ jobs.build.outputs.build-outputs-name }}
       provenance-name:
-        description: "The artifact name of the signed provenance. (A file with the intoto.sigstore extension)."
+        description: "The name of the artifact where the generated provenance are uploaded to the artifact registry."
         value: ${{ jobs.provenance.outputs.provenance-name }}
 
 jobs:
@@ -279,7 +279,7 @@ jobs:
           BUILDER_DIGEST: ${{ inputs.builder-digest }}
           CONFIG_PATH: ${{ inputs.config-path }}
           RNG: ${{ needs.rng.outputs.value }}
-
+          PROVENANCE_NAME: ${{ inputs.provenance-name }}
         run: |
           set -euo pipefail
 
@@ -305,12 +305,29 @@ jobs:
             --subjects-path subjects.json \
             --output-folder /tmp/build-outputs-${RNG}
 
+          # Construct attestation filename.
+          FILENAME=${PROVENANCE_NAME}
+          length=$(jq length subjects.json)
+          if [[ -z "${FILENAME}" ]]; then
+            if [[ "$length" == "1" ]]; then
+              FILENAME=$(jq -r '.[0].name' subjects.json).intoto
+            else
+              FILENAME=multiple.intoto
+            fi
+          fi
+
+          # Validate the filename extension
+          if [[ "${FILENAME}" != *.intoto ]]; then
+            echo "expected provenance-name ${FILENAME} to have .intoto extension"
+            exit 1
+          fi
+
           cat <<EOF >DATA
           {
             "version": 1,
              "attestations": [
               {
-                "name": "attestation.intoto",
+                "name": "${FILENAME}",
                 "subjects": []
               }
             ]
@@ -407,7 +424,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: "${{ env.OUTPUT_FOLDER }}"
+          name: "${{ env.OUTPUT_FOLDER }}-${{ needs.rng.outputs.value }}"
           path: "attestations-${{ needs.rng.outputs.value }}"
           if-no-files-found: error
 

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -84,7 +84,7 @@ on:
           Name of the artifact to download all the attestations.
 
           When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
-          When run on other trggers, attestations are signed and have an "intoto.sigstore" extension.
+          When run on other triggers, attestations are signed and have an "intoto.sigstore" extension.
         value: ${{ jobs.provenance.outputs.provenance-name }}
 
 jobs:

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -79,8 +79,12 @@ on:
       build-outputs-name:
         description: "The name of the artifact where the generated artifacts are uploaded to the artifact registry."
         value: ${{ jobs.build.outputs.build-outputs-name }}
-      provenance-name:
-        description: "The name of the artifact where the generated provenance are uploaded to the artifact registry."
+      attestations-download-name:
+        description: >
+          Name of the artifact to download all the attestations.
+
+          When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
+          When run on other trggers, attestations are signed and have an "intoto.sigstore" extension.
         value: ${{ jobs.provenance.outputs.provenance-name }}
 
 jobs:

--- a/.github/workflows/delegator_generic_slsa3.yml
+++ b/.github/workflows/delegator_generic_slsa3.yml
@@ -64,7 +64,7 @@ on:
           Name of the artifact to download all the attestations.
 
           When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
-          When run on other trggers, attestations are signed and have an "intoto.sigstore" extension.
+          When run on other triggers, attestations are signed and have an "intoto.sigstore" extension.
         value: ${{ jobs.generate-provenance.outputs.attestations-download-name }}
 
 jobs:

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -31,6 +31,7 @@ type that provides the full details on the build process.
   - [Configuration File](#configuration-file)
   - [Workflow Inputs](#workflow-inputs)
   - [Workflow Example](#workflow-example)
+  - [Workflow Outputs](#workflow-outputs)
   - [Provenance Format](#provenance-format)
   - [Provenance Example](#provenance-example)
 - [Command line tool](#command-line-tool)

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -210,7 +210,7 @@ workflow](https://github.com/slsa-framework/slsa-github-generator/blob/main/.git
 | Name               | Description                                                                            |
 | ------------------ | -------------------------------------------------------------------------------------- |
 | `build-outputs-name`  | The name of the artifact where the generated artifacts are uploaded to the artifact registry.       |
-| `provenance-name`          | The name of the artifact where the generated provenance are uploaded to the artifact registry. |
+| `attestations-download-name`          | Name of the artifact to download all the attestations. When run on a `pull_request` trigger, attestations are not signed and have an `.intoto` extension. When run on other trggers, attestations are signed and have an `.intoto.sigstore` extension. |
 
 ### Provenance Format
 

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -169,6 +169,7 @@ Inputs:
 | `builder-digest`                         | **(Required)** The OCI image digest of the builder-image. The image digest of the form '<algorithm>:<digest>' (e.g. 'sha256:abcdef...')                                                                                                                                                                      |
 | `config-path`              | **(Required)** Path to a configuration file relative to the root of the repository containing the command that the builder image should be invoked with and the path to the output artifacts. See [Configuration File](#configuration-file).                                                                                                                                                                  |
 | `compile-builder`              | Whether to build the builder from source. This increases build time by ~2m.<br>Default: `false`.                                                                                                                                                                                      |
+| `provenance-name`             | The artifact name of the signed provenance. The file must have the `.intoto` extension.<br>Defaults to `<filename>.intoto` for single artifact or `multiple.intoto.jsonl` for multiple artifacts.                                    |
 | `rekor-log-public`             | Set to true to opt-in to posting to the public transparency log. Will generate an error if false for private repositories. This input has no effect for public repositories. See [Private Repositories](#private-repositories).<br>Default: `false`                                     |
 
 ### Workflow Example
@@ -199,6 +200,16 @@ jobs:
       builder-digest: "sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
       config-path: ".github/configs-docker/config.toml"
 ```
+
+### Workflow Outputs
+
+The [container-based
+workflow](https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/workflows/builder_docker-based_slsa3.yml) produces the following outputs:
+
+| Name               | Description                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `build-outputs-name`  | The name of the artifact where the generated artifacts are uploaded to the artifact registry.       |
+| `provenance-name`          | The name of the artifact where the generated provenance are uploaded to the artifact registry. |
 
 ### Provenance Format
 

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -210,7 +210,7 @@ workflow](https://github.com/slsa-framework/slsa-github-generator/blob/main/.git
 | Name               | Description                                                                            |
 | ------------------ | -------------------------------------------------------------------------------------- |
 | `build-outputs-name`  | The name of the artifact where the generated artifacts are uploaded to the artifact registry.       |
-| `attestations-download-name`          | Name of the artifact to download all the attestations. When run on a `pull_request` trigger, attestations are not signed and have an `.intoto` extension. When run on other trggers, attestations are signed and have an `.intoto.sigstore` extension. |
+| `attestations-download-name`          | Name of the artifact to download all the attestations. When run on a `pull_request` trigger, attestations are not signed and have an `.intoto` extension. When run on other triggers, attestations are signed and have an `.intoto.sigstore` extension. |
 
 ### Provenance Format
 

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -546,7 +546,11 @@ func inspectAndWriteArtifacts(pattern, outputFolder, root string) ([]intoto.Subj
 
 		if outputFolder != "" {
 			// Write output file to output folder
-			relPath, err := filepath.Rel(root, path)
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return nil, err
+			}
+			relPath, err := filepath.Rel(root, absPath)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -545,14 +545,15 @@ func inspectAndWriteArtifacts(pattern, outputFolder, root string) ([]intoto.Subj
 		subjects = append(subjects, *subject)
 
 		if outputFolder != "" {
-			// Write output file to output folder
+			// Write output file to output folder using the path relative to the root
+			// of the source repository.
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return nil, err
 			}
 			relPath, err := filepath.Rel(root, absPath)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("Root %s Path %s: %w", root, path, err)
 			}
 			w, err := utils.CreateNewFileUnderDirectory(relPath, outputFolder, os.O_WRONLY)
 			if err != nil {

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -547,11 +547,13 @@ func inspectAndWriteArtifacts(pattern, outputFolder, root string) ([]intoto.Subj
 		if outputFolder != "" {
 			// Write output file to output folder using the path relative to the root
 			// of the source repository.
-			absPath, err := filepath.Abs(path)
-			if err != nil {
-				return nil, err
+			if root != "" {
+				path, err = filepath.Abs(path)
+				if err != nil {
+					return nil, err
+				}
 			}
-			relPath, err := filepath.Rel(root, absPath)
+			relPath, err := filepath.Rel(root, path)
 			if err != nil {
 				return nil, fmt.Errorf("Root %s Path %s: %w", root, path, err)
 			}

--- a/internal/builders/docker/pkg/builder_test.go
+++ b/internal/builders/docker/pkg/builder_test.go
@@ -16,6 +16,7 @@ package pkg
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -163,7 +164,12 @@ func Test_inspectArtifacts(t *testing.T) {
 	// Note: If the files in ../testdata/ change, this test must be updated.
 	pattern := "../testdata/*"
 	out := t.TempDir()
-	got, err := inspectAndWriteArtifacts(pattern, out, "..")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := inspectAndWriteArtifacts(pattern, out, filepath.Dir(wd))
 	if err != nil {
 		t.Fatalf("failed to inspect artifacts: %v", err)
 	}

--- a/internal/builders/docker/pkg/builder_test.go
+++ b/internal/builders/docker/pkg/builder_test.go
@@ -210,7 +210,11 @@ func Test_inspectArtifactsNoRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(wd)
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatal(err)
+		}
+	})
 	if err := os.Chdir(".."); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/builders/docker/pkg/builder_test.go
+++ b/internal/builders/docker/pkg/builder_test.go
@@ -200,6 +200,52 @@ func Test_inspectArtifacts(t *testing.T) {
 	}
 }
 
+// When running in the checkout of the repository root, root == "".
+func Test_inspectArtifactsNoRoot(t *testing.T) {
+	// Note: If the files in ../testdata/ change, this test must be updated.
+	pattern := "testdata/*"
+	out := t.TempDir()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := inspectAndWriteArtifacts(pattern, out, "")
+	if err != nil {
+		t.Fatalf("failed to inspect artifacts: %v", err)
+	}
+
+	s1 := intoto.Subject{
+		Name:   "build-definition.json",
+		Digest: map[string]string{"sha256": "fbe3d5448f3e43b20368c223eda70ecbf41bbe6e5956ee81b5d490c1753ea118"},
+	}
+	s2 := intoto.Subject{
+		Name:   "config.toml",
+		Digest: map[string]string{"sha256": "975a0582b8c9607f3f20a6b8cfef01b25823e68c5c3658e6e1ccaaced2a3255d"},
+	}
+
+	s3 := intoto.Subject{
+		Name:   "slsa1-provenance.json",
+		Digest: map[string]string{"sha256": "d40de4149c9ad41d2fdcba44ddb2be1760eb4fbb01644f7ddf9ed0a424d7ed44"},
+	}
+
+	s4 := intoto.Subject{
+		Name:   "wildcard-config.toml",
+		Digest: map[string]string{"sha256": "d9b8670f1b9616db95b0dc84cbc68062c691ef31bb9240d82753de0739c59194"},
+	}
+
+	want := []intoto.Subject{s1, s2, s3, s4}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf(diff)
+	}
+}
+
 type testFetcher struct{}
 
 func (testFetcher) Fetch() (*RepoCheckoutInfo, error) {


### PR DESCRIPTION
Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1638

* Adds a `provenance-name` input option to the docker builder to configure the name of the attestation that gets uploaded
* Updates docs
* Renames `provenance-name` output to `attestations-download-name` for consistency
* Fixes a bug when using a `--force-checkout` locally, the build output needs to be absolute to generate the relative path.

cc @rbehjati this will fix an issue I noticed in https://github.com/project-oak/oak/actions/runs/4312859723 where the attestation was using the same name. Also checkout the workflow output documentation for the location of the build/provenance output.