### PR TITLE
fix: fix GITHUB_WORKFLOW check

### DIFF
--- a/.github/workflows/e2e.detect-workflow-js.schedule.yml
+++ b/.github/workflows/e2e.detect-workflow-js.schedule.yml
@@ -40,8 +40,9 @@ jobs:
           fi
           # When calling this action from a caller workflow, this will be
           # the caller workflow.
-          if [[ "${WORKFLOW}" != "${GITHUB_WORKFLOW}" ]]; then
-            echo "expected ${GITHUB_WORKFLOW}, got ${WORKFLOW}"
+          workflow=$(echo "${GITHUB_WORKFLOW_REF}" | cut -d '@' -f1 | cut -d '/' -f3-)
+          if [[ "${WORKFLOW}" != "${workflow}" ]]; then
+            echo "expected ${workflow}, got ${WORKFLOW}"
             exit 1
           fi
 


### PR DESCRIPTION
See run https://github.com/slsa-framework/slsa-github-generator/actions/runs/4334298905/jobs/7568100586#step:4:27

Fixes verification comparison of the workflow (something like .github/workflows/example.yml) emitted by `detect-workflow-js` and the expected value. 