### PR TITLE
fix: fix schedule tests with fixed sha

### DIFF
--- a/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-docker_based-predicate.schedule.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Detect the builder ref
         id: detect
         uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow@main
+      - name: Update the build definition
+        # We use a build definition hard-coded in testadata. To ensure validation against
+        # workflow context, we must update the source references.
+        run: |
+          bdTemplate="internal/builders/docker/testdata/build-definition.json"
+          jq  -r --arg GITHUB_SHA "$GITHUB_SHA" '.externalParameters.source.digest.sha1 = $GITHUB_SHA' "${bdTemplate}" > build-definition.json
       - name: Create predicate
         id: predicate
         uses: ./.github/actions/create-docker_based-predicate


### PR DESCRIPTION
The testadata build-definition.json includes a hard-coded SHA, while the verification script generally tests against the `GITHUB_SHA` env var.