### PR TITLE
fix: Update cosign flag

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -207,7 +207,7 @@ jobs:
 
           COSIGN_EXPERIMENTAL=1 cosign attest --predicate="$predicate_name" \
             --type slsaprovenance \
-            --force \
+            --yes \
             "${UNTRUSTED_IMAGE}@${UNTRUSTED_DIGEST}"
 
       - name: Final outcome


### PR DESCRIPTION
This PR fixes workflow failure for generic container.

* `--force` flag is removed by https://github.com/sigstore/cosign/pull/2399
* Use `--yes` instead of `--force`