### PR TITLE
fix: fix build definition testdata

### DIFF
--- a/internal/builders/docker/testdata/build-definition.json
+++ b/internal/builders/docker/testdata/build-definition.json
@@ -2,7 +2,7 @@
     "buildType": "https://slsa.dev/container-based-build/v0.1?draft",
     "externalParameters": {
         "source": {
-            "uri": "git+https://github.com/slsa-framework/slsa-github-generator",
+            "uri": "git+https://github.com/slsa-framework/slsa-github-generator@refs/heads/main",
             "digest": {
                 "sha1": "cf5804b5c6f1a4b2a0b03401a487dfdfbe3a5f00"
             }


### PR DESCRIPTION
the build definition produces by the builder includes the GITHUB_REF in the workflow:

https://github.com/slsa-framework/slsa-github-generator/blob/80da39e3f22bc13d965dfbccc408098ca2f362fe/.github/workflows/builder_docker-based_slsa3.yml#L220