### PR TITLE
test: add docker-based provenance content verification on presubmit

### DIFF
--- a/.github/workflows/pre-submit.e2e.docker-based.default.yml
+++ b/.github/workflows/pre-submit.e2e.docker-based.default.yml
@@ -22,4 +22,25 @@ jobs:
       builder-image: "bash"
       builder-digest: "sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
       config-path: "internal/builders/docker/testdata/wildcard-config.toml"
+      provenance-name: "attestation.intoto"
       compile-builder: true
+
+  verify:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
+        with:
+          name: ${{ needs.build.outputs.build-outputs-name }}
+          path: outputs
+      - name: Get build artifact
+        id: build
+        run: |
+          name=$(find outputs/ -type f | head -1)
+          cp $name .
+          echo "name=$name" >> $GITHUB_OUTPUT
+      - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
+        with:
+          name: ${{ needs.build.outputs.attestations-download-name }}
+      - run: ./.github/workflows/scripts/pre-submit.e2e.docker-based.default.sh

--- a/.github/workflows/pre-submit.e2e.docker-based.default.yml
+++ b/.github/workflows/pre-submit.e2e.docker-based.default.yml
@@ -43,4 +43,7 @@ jobs:
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
-      - run: ./.github/workflows/scripts/pre-submit.e2e.docker-based.default.sh
+      - env:
+          BINARY: ${{ steps.build.outputs.name }}
+          PROVENANCE: attestation.intoto
+        run: ./.github/workflows/scripts/pre-submit.e2e.docker-based.default.sh

--- a/.github/workflows/scripts/pre-submit.e2e.docker-based.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.docker-based.default.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 SLSA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "./.github/workflows/scripts/e2e-verify.common.sh"
+
+# TODO(github.com/slsa-framework/slsa-github-generator/issues/129): Address base64 output format.
+ATTESTATION=$(cat "$PROVENANCE")
+
+# Verify all common provenance fields.
+e2e_verify_common_all_v1 "$ATTESTATION"
+
+e2e_verify_predicate_subject_name "$ATTESTATION" "$BINARY"
+e2e_verify_predicate_v1_runDetails_builder_id "$ATTESTATION" "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_docker-based_slsa3.yml@refs/heads/main"
+e2e_verify_predicate_v1_buildDefinition_buildType "$ATTESTATION" "https://slsa.dev/container-based-build/v0.1?draft"


### PR DESCRIPTION
Fixes https://github.com/slsa-framework/slsa-github-generator/issues/1784

Adds content verification for the provenance generated on presubmit for docker-based