### PR TITLE
fix: Fix setup-token script

### DIFF
--- a/.github/workflows/scripts/schedule.actions/setup-token.sh
+++ b/.github/workflows/scripts/schedule.actions/setup-token.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source "./.github/workflows/scripts/e2e-utils.sh"
+source "./.github/workflows/scripts/e2e-verify.common.sh"
 
 # TODO(#1709): Add more token verification.
 if [[ "$SLSA_TOKEN" == "" ]]; then


### PR DESCRIPTION
Fixes #1759

Updates the script to use the right import to get the `e2e_verify_decoded_token` function.

Signed-off-by: Ian Lewis <ianlewis@google.com>