### PR TITLE
fix: fix runner verification of predicate

### DIFF
--- a/.github/workflows/scripts/e2e-utils.sh
+++ b/.github/workflows/scripts/e2e-utils.sh
@@ -84,8 +84,8 @@ _e2e_verify_query() {
 _e2e_verify_presence() {
     local attestation="$1"
     local query="$2"
-    name=$(echo -n "${attestation}" | jq -c -r "${query}")
-    assert_true "${name}" "${query} should be ${expected}"
+    name=$(echo -n "${attestation}" | jq -c -r "${query} | select(type != \"null\")")
+    assert_not_empty "${name}" "${query} should not be empty"
 }
 
 e2e_verify_predicate_v1_buildDefinition_externalParameters_workflow_path() {

--- a/.github/workflows/scripts/e2e-utils.sh
+++ b/.github/workflows/scripts/e2e-utils.sh
@@ -80,6 +80,14 @@ _e2e_verify_query() {
     e2e_assert_eq "${name}" "${expected}" "${query} should be ${expected}"
 }
 
+# _e2e_verify_presence verifies that the result of the given jq query is present.
+_e2e_verify_presence() {
+    local attestation="$1"
+    local query="$2"
+    name=$(echo -n "${attestation}" | jq -c -r "${query}")
+    assert_true "${name}" "${query} should be ${expected}"
+}
+
 e2e_verify_predicate_v1_buildDefinition_externalParameters_workflow_path() {
     _e2e_verify_query "$1" "$2" '.buildDefinition.externalParameters.workflow.path'
 }
@@ -102,6 +110,10 @@ e2e_verify_predicate_v1_buildDefinition_resolvedDependencies() {
 
 e2e_verify_predicate_v1_buildDefinition_systemParameters() {
     _e2e_verify_query "$1" "$3" '.buildDefinition.systemParameters.'"$2"
+}
+
+e2e_present_predicate_v1_buildDefinition_systemParameters() {
+    _e2e_verify_presence "$1" '.buildDefinition.systemParameters.'"$2"
 }
 
 e2e_verify_predicate_v1_runDetails_builder_id() {

--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -90,7 +90,6 @@ e2e_verify_common_buildDefinition_v1() {
     # verifies.
     e2e_present_predicate_v1_buildDefinition_systemParameters "$1" "RUNNER_NAME"
     e2e_present_predicate_v1_buildDefinition_systemParameters "$1" "IMAGE_VERSION"
-
 }
 
 # Verifies common fields of the SLSA v1.0 predicate runDetails.

--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -84,11 +84,13 @@ e2e_verify_common_buildDefinition_v1() {
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "GITHUB_WORKFLOW_SHA" "$GITHUB_WORKFLOW_SHA"
     # shellcheck disable=SC2154
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "IMAGE_OS" "$ImageOS"
-    # shellcheck disable=SC2154
-    e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "IMAGE_VERSION" "$ImageVersion"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "RUNNER_ARCH" "$RUNNER_ARCH"
-    e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "RUNNER_NAME" "$RUNNER_NAME"
     e2e_verify_predicate_v1_buildDefinition_systemParameters "$1" "RUNNER_OS" "$RUNNER_OS"
+    # These may differ between the jobs that created the predicate and the job that
+    # verifies.
+    e2e_present_predicate_v1_buildDefinition_systemParameters "$1" "RUNNER_NAME"
+    e2e_present_predicate_v1_buildDefinition_systemParameters "$1" "IMAGE_VERSION"
+
 }
 
 # Verifies common fields of the SLSA v1.0 predicate runDetails.


### PR DESCRIPTION
May fix https://github.com/slsa-framework/slsa-github-generator/issues/1809

* RUNNER_NAME and RUNNER_VERSION may differ between the jobs that create the predicate and the one that verifies, so only test for presence of the field. 