### PR TITLE
feat: Generate SLSA v0.2 for nodejs builder

### DIFF
--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -50,6 +50,7 @@ jobs:
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
           slsa-runner-label: "ubuntu-latest"
           slsa-build-action-path: "./internal/nodejs-action"
+          slsa-version: "v0.2"
           # TODO(#1575): mask sensitive fields.
           slsa-workflow-inputs: ${{ toJson(inputs) }}
 


### PR DESCRIPTION
Pass the `slsa-version` option to `setup-token` in the Node.js builder.