### PR TITLE
fix: make registry-username optional

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -300,7 +300,7 @@ jobs:
             username="${UNTRUSTED_SECRET_USERNAME:-${UNTRUSTED_INPUT_USERNAME}}"
             if [ "${username}" == "" ]; then
                 # This may be the case for public base images.
-                echo "registry-username is not provided, skipping login." >&2
+                echo "registry-username is not provided, skipping login."
                 exit 0
             fi
             # A username is present, so a password must be provided.

--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -90,6 +90,7 @@ on:
       registry-username:
         description: "Username to log into the container registry."
         type: string
+        required: false
       gcp-workload-identity-provider:
         description: >
           The full identifier of the Workload Identity Provider, including the project
@@ -298,9 +299,11 @@ jobs:
           else
             username="${UNTRUSTED_SECRET_USERNAME:-${UNTRUSTED_INPUT_USERNAME}}"
             if [ "${username}" == "" ]; then
-                echo "registry-username is required." >&2
-                exit 1
+                # This may be the case for public base images.
+                echo "registry-username is not provided, skipping login." >&2
+                exit 0
             fi
+            # A username is present, so a password must be provided.
             password="${UNTRUSTED_PASSWORD}"
             if [ "${password}" == "" ]; then
                 echo "registry-password is required." >&2

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -102,9 +102,10 @@ name information is tracked on [issue
 
 ### Registry Authentication
 
-This workflow support authentication against a Docker registry through an input
-`registry-username` and `registry-password` secret. See [Workflow Inputs](#workflow-inputs)
-for more.
+This workflow support authentication against a Docker registry for private base images
+through an input `registry-username` and `registry-password` secret. Authentication is
+not required for public base images.
+See [Workflow Inputs](#workflow-inputs) for more.
 
 Authentication to GCR using GCP workflow identity federation is also supported using
 `gcp-workload-identity-provider` and `gcp-service-account`.
@@ -168,7 +169,7 @@ Inputs:
 | `compile-builder`              | Whether to build the builder from source. This increases build time by ~2m.<br>Default: `false`.                                                                                                                                                                                      |
 | `provenance-name`             | The artifact name of the signed provenance. The file must have the `.intoto` extension.<br>Defaults to `<filename>.intoto` for single artifact or `multiple.intoto.jsonl` for multiple artifacts.                                    |
 | `rekor-log-public`             | Set to true to opt-in to posting to the public transparency log. Will generate an error if false for private repositories. This input has no effect for public repositories. See [Private Repositories](#private-repositories).<br>Default: `false`                                     |
-| `registry-username`              | Username to log in the container registry. Either `registry-username` input or `registry-username` secret is required.                                                                                                                                                                  |
+| `registry-username`              | Username to log in the container registry.                                                                                                                                                                 |
 | `gcp-workload-identity-provider` | The full identifier of the Workload Identity Provider, including the project number, pool name, and provider name. If provided, this must be the full identifier which includes all parts:<br>`projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider` |
 | `gcp-service-account`            | Email address or unique identifier of the Google Cloud service account for which to generate credentials. For example:<br>`my-service-account@my-project.iam.gserviceaccount.com`                                                                                                       |
 
@@ -176,7 +177,7 @@ Secrets:
 
 | Name                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `registry-username` | Username to log in the container registry. Either `registry-username` input or `registry-username` secret is required. This should only be used for high entropy values such as AWS Access Key as described [here](https://github.com/docker/login-action#aws-elastic-container-registry-ecr). Normal username values could match other input values and cause them to be ignored by GitHub Actions and causing your build to fail. In those cases, use the `registry-username` input instead. |
+| `registry-username` | Username to log in the container registry. This should only be used for high entropy values such as AWS Access Key as described [here](https://github.com/docker/login-action#aws-elastic-container-registry-ecr). Normal username values could match other input values and cause them to be ignored by GitHub Actions and causing your build to fail. In those cases, use the `registry-username` input instead. |
 | `registry-password` | **(Required)** Password to log in the container registry. |
 
 ### Workflow Example

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -178,7 +178,7 @@ Secrets:
 | Name                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `registry-username` | Username to log in the container registry. This should only be used for high entropy values such as AWS Access Key as described [here](https://github.com/docker/login-action#aws-elastic-container-registry-ecr). Normal username values could match other input values and cause them to be ignored by GitHub Actions and causing your build to fail. In those cases, use the `registry-username` input instead. |
-| `registry-password` | **(Required)** Password to log in the container registry. |
+| `registry-password` | Password to log in the container registry. Required if a `registry-username` is provided |
 
 ### Workflow Example
 


### PR DESCRIPTION
In the case of public base images, registry-username or gcp username may both be empty