### PR TITLE
ci: Do clean comparison in check-dist pre-submit

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Rebuild the dist/ directory
         working-directory: ${{ matrix.action }}
-        run: make package
+        run: make clean package
 
       - name: Compare the expected and actual dist/ directories
         working-directory: ${{ matrix.action }}


### PR DESCRIPTION
Updates `check-dist` to clean the package dist directory before building the package so that it does a clean comparison. This is most useful when files get moved around or renamed.