### PR TITLE
fix:  Check that the output folder is empty

### DIFF
--- a/internal/builders/docker/commands.go
+++ b/internal/builders/docker/commands.go
@@ -85,6 +85,7 @@ func BuildCmd(check func(error)) *cobra.Command {
 			if !strings.HasPrefix(filepath.Dir(absoluteOutputFolder), "/tmp") {
 				check(fmt.Errorf("output folder must be in /tmp: %s", absoluteOutputFolder))
 			}
+			check(pkg.CheckExistingFiles(absoluteOutputFolder))
 
 			w, err := utils.CreateNewFileUnderCurrentDirectory(subjectsPath, os.O_WRONLY)
 			check(err)

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -153,7 +153,7 @@ func (b *Builder) SetUpBuildState() (*DockerBuild, error) {
 
 	// 3. Check that the ArtifactPath pattern does not match any existing files,
 	// so that we don't accidentally generate provenances for the wrong files.
-	if err := checkExistingFiles(bc.ArtifactPath); err != nil {
+	if err := CheckExistingFiles(bc.ArtifactPath); err != nil {
 		return nil, err
 	}
 
@@ -501,8 +501,8 @@ func saveToTempFile(readers ...io.Reader) ([]string, error) {
 	return files, nil
 }
 
-// Checks if any files match the given pattern, and returns an error if so.
-func checkExistingFiles(pattern string) error {
+// CheckExistingFiles checks if any files match the given pattern, and returns an error if so.
+func CheckExistingFiles(pattern string) error {
 	matches, err := filepath.Glob(pattern)
 	// The only possible error is ErrBadPattern.
 	if err != nil {


### PR DESCRIPTION
Currently, if the give output folder is not only, the `build` command only fails after the build is completed and when copying the files to the output folder. With this change this situation is detected earlier.