### PR TITLE
feat: Add a verbose option to the docker-builder

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -250,13 +250,15 @@ jobs:
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
+            --verbose
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" dry-run \
             --build-config-path "${CONFIG_PATH}" \
             --build-definition-path build-definition.json \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
-            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}"
+            --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
+            --verbose
 
           echo "build-definition-name=build-definition.json" >> $GITHUB_OUTPUT
 
@@ -387,14 +389,16 @@ jobs:
             --git-commit-digest "sha1:${GITHUB_SHA}" \
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
             --subjects-path subjects.json \
-            --output-folder /tmp/build-outputs-${RNG}
+            --output-folder /tmp/build-outputs-${RNG} \
+            --verbose
           "${GITHUB_WORKSPACE}/${BUILDER_BINARY}" build \
             --build-config-path "${CONFIG_PATH}" \
             --builder-image "${BUILDER_IMAGE}@${BUILDER_DIGEST}" \
             --git-commit-digest "sha1:${GITHUB_SHA}" \
             --source-repo "git+https://github.com/${GITHUB_REPOSITORY}${REF}" \
             --subjects-path subjects.json \
-            --output-folder /tmp/build-outputs-${RNG}
+            --output-folder /tmp/build-outputs-${RNG} \
+            --verbose
 
           # Construct attestation filename.
           FILENAME=${PROVENANCE_NAME}

--- a/internal/builders/docker/pkg/config.go
+++ b/internal/builders/docker/pkg/config.go
@@ -66,6 +66,7 @@ type DockerBuildConfig struct {
 	BuilderImage    DockerImage
 	BuildConfigPath string
 	ForceCheckout   bool
+	Verbose         bool
 }
 
 // NewDockerBuildConfig validates the inputs and generates an instance of
@@ -95,6 +96,7 @@ func NewDockerBuildConfig(io *InputOptions) (*DockerBuildConfig, error) {
 		BuilderImage:    *dockerImage,
 		BuildConfigPath: io.BuildConfigPath,
 		ForceCheckout:   io.ForceCheckout,
+		Verbose:         io.Verbose,
 	}, nil
 }
 

--- a/internal/builders/docker/pkg/options.go
+++ b/internal/builders/docker/pkg/options.go
@@ -23,6 +23,7 @@ type InputOptions struct {
 	GitCommitHash   string
 	BuilderImage    string
 	ForceCheckout   bool
+	Verbose         bool
 }
 
 // AddFlags adds input flags to the given command.
@@ -41,4 +42,7 @@ func (io *InputOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVarP(&io.ForceCheckout, "force-checkout", "f", false,
 		"Optional - Forces checking out the source code from the given Git repo.")
+
+	cmd.Flags().BoolVarP(&io.Verbose, "verbose", "v", false,
+		"Optional - Prints all logs and errors in console.")
 }


### PR DESCRIPTION
Tested with `build` and `dry-run` commands.
For `build` tested with an invalid image digest, and the errors are printed to console.