### PR TITLE
feat: Move npm cli fork to slsa-framework org

### DIFF
--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -150,8 +150,10 @@ jobs:
         env:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
-          NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          NPM_GIT_SHA: "208a431b1d35af69f03437388b7d6332d4125667"
+          # NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
+          # NPM_GIT_SHA: "208a431b1d35af69f03437388b7d6332d4125667"
+          NPM_REMOTE_URL: "https://github.com/ianlewis/cli.git"
+          NPM_GIT_SHA: "bc657b76f09cbdd5801e360633898b14a4bbc5e8"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -151,9 +151,7 @@ jobs:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
           NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          NPM_GIT_SHA: "b3e7b58fc4f267d95ce502d770ceeb245ed3f5b9"
-          # NPM_REMOTE_URL: "https://github.com/ianlewis/cli.git"
-          # NPM_GIT_SHA: "bc657b76f09cbdd5801e360633898b14a4bbc5e8"
+          NPM_GIT_SHA: "3ac007572ec6aa13b66cd13fec806130e22a69b8"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -150,10 +150,10 @@ jobs:
         env:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
-          # NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          # NPM_GIT_SHA: "208a431b1d35af69f03437388b7d6332d4125667"
-          NPM_REMOTE_URL: "https://github.com/ianlewis/cli.git"
-          NPM_GIT_SHA: "bc657b76f09cbdd5801e360633898b14a4bbc5e8"
+          NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
+          NPM_GIT_SHA: "b3e7b58fc4f267d95ce502d770ceeb245ed3f5b9"
+          # NPM_REMOTE_URL: "https://github.com/ianlewis/cli.git"
+          # NPM_GIT_SHA: "bc657b76f09cbdd5801e360633898b14a4bbc5e8"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -148,7 +148,10 @@ jobs:
       - name: Clone npm fork
         id: clone-fork
         env:
-          NPM_GIT_SHA: bc657b76f09cbdd5801e360633898b14a4bbc5e8
+          # This points to the slsa-framework/npm-cli oob-provenance branch
+          # which contains patches to the v9.6.5 release of the npm cli.
+          NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
+          NPM_GIT_SHA: "a9008fa54ec3afa3bb0848f1384896893757bcef"
         run: |
           set -euo pipefail
 
@@ -157,7 +160,7 @@ jobs:
           mkdir -p node_modules/npm
           cd node_modules/npm
           git init
-          git remote add origin https://github.com/ianlewis/cli.git
+          git remote add origin "${NPM_REMOTE_URL}"
 
           # Fetch and checkout oob-provenance branch at pinned digest.
           git fetch --depth 1 origin "${NPM_GIT_SHA}"

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -151,7 +151,7 @@ jobs:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
           NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          NPM_GIT_SHA: "3ac007572ec6aa13b66cd13fec806130e22a69b8"
+          NPM_GIT_SHA: "be87719832648731541cf6019c00320f479cafe5"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -151,7 +151,7 @@ jobs:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
           NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          NPM_GIT_SHA: "a9008fa54ec3afa3bb0848f1384896893757bcef"
+          NPM_GIT_SHA: "52681adf9f0dc29a3ea7a0b1d287ecb5c80ef5a1"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -151,7 +151,7 @@ jobs:
           # This points to the slsa-framework/npm-cli oob-provenance branch
           # which contains patches to the v9.6.5 release of the npm cli.
           NPM_REMOTE_URL: "https://github.com/slsa-framework/npm-cli.git"
-          NPM_GIT_SHA: "52681adf9f0dc29a3ea7a0b1d287ecb5c80ef5a1"
+          NPM_GIT_SHA: "208a431b1d35af69f03437388b7d6332d4125667"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -255,4 +255,4 @@ jobs:
           # Run npm publish using npm fork. We are temporarily using a fork so
           # that we can specify the provenance bundle.
           # NOTE: We don't quote $publish_flags because we are using word splitting to add the flags.
-          "$(dirname "$(which node)")"/node_modules/npm/bin/npm publish "${PACKAGE_PATH}" ${publish_flags}
+          "$(dirname "$(which node)")"/node_modules/npm/bin/npm publish --loglevel verbose "${PACKAGE_PATH}" ${publish_flags}


### PR DESCRIPTION
This moves the npm cli fork from [ianlewis/cli@oob-provenance](https://github.com/ianlewis/cli/tree/oob-provenance) to  [slsa-framework/npm-cli@oob-provenance](https://github.com/slsa-framework/npm-cli/tree/oob-provenance).

The commits on the repo have been cleaned up to be a single patch on the v9.6.5 release of the npm cli.