### PR TITLE
chore: update slsa version to v1.0 in docker-based workflow

### DIFF
--- a/.github/workflows/builder_docker-based_slsa3.yml
+++ b/.github/workflows/builder_docker-based_slsa3.yml
@@ -516,7 +516,7 @@ jobs:
         with:
           slsa-layout-file: "${{ needs.build.outputs.slsa-outputs-name }}"
           predicate-file: "predicate-${{ needs.rng.outputs.value }}"
-          predicate-type: "https://slsa.dev/provenance/v1.0?draft"
+          predicate-type: "https://slsa.dev/provenance/v1"
           output-folder: "attestations-${{ needs.rng.outputs.value }}"
 
       - name: Upload unsigned intoto attestations file for pull request

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -256,7 +256,7 @@ as an [in-toto](https://in-toto.io/) statement with a SLSA predicate.
       }
     }
   ],
-  "predicateType": "https://slsa.dev/provenance/v1.0?draft",
+  "predicateType": "https://slsa.dev/provenance/v1",
   "predicate": {
     "buildDefinition": {
       "buildType": "https://slsa.dev/container-based-build/v0.1?draft",


### PR DESCRIPTION
Updates the predicate type version string in generate-attestations to v1.0 for docker-based builder.

This is needed to fix https://github.com/slsa-framework/slsa-github-generator/issues/1997 as I update https://github.com/slsa-framework/slsa-verifier/issues/561