### PR TITLE
fix: fix test script for container_based predicate

### DIFF
--- a/.github/workflows/scripts/schedule.actions/verify-container_based-predicate.sh
+++ b/.github/workflows/scripts/schedule.actions/verify-container_based-predicate.sh
@@ -30,5 +30,5 @@ e2e_verify_predicate_v1_runDetails_builder_id "$PREDICATE_CONTENT" "https://gith
 
 # Verify source
 e2e_verify_predicate_v1_buildDefinition_externalParameters_source "$PREDICATE_CONTENT" "{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha1\":\"$GITHUB_SHA\"}}"
-# Verify resolved dependencies.
-e2e_verify_predicate_v1_buildDefinition_resolvedDependencies "$PREDICATE_CONTENT" "[{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha256\":\"46b3ce0fbb2998880c5518225b41ddf49fc0850b9b9a25e1ac944bc587c03ea7\"}}]"
+# Verify resolved dependencies contains both the source and repo commit (first) and then builder binary with a sha256 digest of its binary.
+e2e_verify_predicate_v1_buildDefinition_resolvedDependencies "$PREDICATE_CONTENT" "[{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha1\":\"$GITHUB_SHA\"}},{\"uri\":\"git+https://github.com/$GITHUB_REPOSITORY@$GITHUB_REF\",\"digest\":{\"sha256\":\"46b3ce0fbb2998880c5518225b41ddf49fc0850b9b9a25e1ac944bc587c03ea7\"}}]"


### PR DESCRIPTION
The container-based predicate's resolvedDependencies contains (1) the source with repo & commit sha and (2) the builder binary reference. 

I didn't update the scheduled e2e testing script to check for both after adding both references.

Fixes:
https://github.com/slsa-framework/slsa-github-generator/actions/runs/5151801823/jobs/9277322271
