### PR TITLE
fix: fix another test script issue with scheduled predicate action

### DIFF
--- a/.github/workflows/e2e.create-container_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-container_based-predicate.schedule.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           bdTemplate="internal/builders/docker/testdata/build-definition.json"
           jq  -r --arg GITHUB_SHA "$GITHUB_SHA" '.externalParameters.source.digest.sha1 = $GITHUB_SHA' "${bdTemplate}" > build-definition.json
+          jq  -r --arg GITHUB_SHA "$GITHUB_SHA" '.resolvedDependencies.source.digest.sha1 = $GITHUB_SHA' "${bdTemplate}" > build-definition.json
       - name: Create predicate
         id: predicate
         uses: ./.github/actions/create-container_based-predicate


### PR DESCRIPTION
https://github.com/slsa-framework/slsa-github-generator/actions/runs/5159223240/jobs/9293876076

Fixes another issue - the e2e schedule script needs to update both references of the source in the buildDefinition.json.