### PR TITLE
feat: rename setup-token to setup-generic (slsa-framework#2176)

### DIFF
--- a/.github/workflows/builder_gradle_slsa3.yml
+++ b/.github/workflows/builder_gradle_slsa3.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-token@main
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@main
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}

--- a/.github/workflows/builder_maven_slsa3.yml
+++ b/.github/workflows/builder_maven_slsa3.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-token@main
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@main
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}


### PR DESCRIPTION
Gradle and Maven builders referenced setup-token. Changed to use setup-generic now.