### PR TITLE
docs: Update BYOB doc

### DIFF
--- a/.github/workflows/delegator_generic_slsa3.yml
+++ b/.github/workflows/delegator_generic_slsa3.yml
@@ -65,8 +65,7 @@ on:
         description: >
           Name of the artifact to download all the attestations.
 
-          When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
-          When run on other triggers, attestations are signed and have an "intoto.sigstore" extension.
+          Attestations are signed and have an "build.slsa" extension.
         value: ${{ jobs.generate-provenance.outputs.attestations-download-name }}
 
       attestations-download-sha256:

--- a/.github/workflows/delegator_lowperms-generic_slsa3.yml
+++ b/.github/workflows/delegator_lowperms-generic_slsa3.yml
@@ -69,8 +69,7 @@ on:
         description: >
           Name of the artifact to download all the attestations.
 
-          When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
-          When run on other triggers, attestations are signed and have an "intoto.sigstore" extension.
+          Attestations are signed and have an "build.slsa" extension.
         value: ${{ jobs.generate-provenance.outputs.attestations-download-name }}
 
       attestations-download-sha256:

--- a/.github/workflows/scripts/pre-submit.delegators/expected.diff
+++ b/.github/workflows/scripts/pre-submit.delegators/expected.diff
@@ -6,13 +6,13 @@
 > # GITHUB_TOKEN permissions from end-users.
 > 
 > name: SLSA low-permission builder delegator
-77a82
+76a81
 > 
-106c111
+105c110
 <           slsa-workflow-recipient: "delegator_generic_slsa3.yml"
 ---
 >           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
-138,140c143
+137,139c142
 <       # TODO(#2076): Use dynamic GITHUB_TOKEN permissions.
 <       contents: write # To release assets.
 <       packages: write # To publish to GitHub packages.

--- a/BYOB.md
+++ b/BYOB.md
@@ -101,8 +101,26 @@ In this example, we will assume there is an existing [GitHub Action](https://git
 
 ### Supported Triggers
 
-The following triggers are supported: `create`, `release`, `push` and `workflow_dispatch`, as recommended by the [SLSA specifications](https://github.com/slsa-framework/github-actions-buildtypes/tree/main/workflow/v1#description).
+Only the following [event types] are supported as recommended by the [SLSA specifications](https://github.com/slsa-framework/github-actions-buildtypes/tree/main/workflow/v1#description):
 
+| Supported event type  | Event description                          |
+| --------------------- | ------------------------------------------ |
+| [`create`]            | Creation of a git tag or branch.           |
+| [`release`]           | Creation or update of a GitHub release.    |
+| [`push`]              | Creation or update of a git tag or branch. |
+| [`workflow_dispatch`] | Manual trigger of a workflow.              |
+
+`pull_request` events are currently not supported. If you would like support for
+`pull_request`, please tell us about your use case on
+[issue #358](https://github.com/slsa-framework/slsa-github-generator/issues/358). If
+you have an issue related to any other triggers please submit a
+[new issue](https://github.com/slsa-framework/slsa-github-generator/issues/new/choose).
+
+[event types]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+[`create`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create
+[`release`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+[`push`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+[`workflow_dispatch`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
 ### TRW inputs
 
 The first step for our integration is to create our TRW file and define its inputs. The inputs should mirror those of the existing Action above that we want to make SLSA compliant.

--- a/BYOB.md
+++ b/BYOB.md
@@ -11,6 +11,7 @@
     - [SLSA Setup Action (SSA)](#slsa-setup-action-ssa)
     - [SLSA Reusable Workflow (SRW)](#slsa-reusable-workflow-srw)
 - [Integration Steps](#integration-steps)
+  - [Supported Triggers](#supported-triggers)
   - [TRW inputs](#trw-inputs)
     - [Inputs](#inputs)
     - [Secrets](#secrets)
@@ -97,6 +98,10 @@ The SRW acts as the build's orchestrator. It calls the TCA, generates provenance
 ## Integration Steps
 
 In this example, we will assume there is an existing [GitHub Action](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml) which builds an artifact. The Action is fairly simple: it just [echos the parameters into the artifact](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml#L58). It also takes a [username, password and token](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml#L31-L34) to retrieve / push information from a remote registry. Like popular release Actions, it [releases the built artifact to GitHub releases](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml#L67-L78). It outputs the [name of the built artifact and the status of the build](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml#L35-L41). See the full [action.yml](https://github.com/laurentsimon/byob-doc/tree/v0.0.1/action.yml).
+
+### Supported Triggers
+
+The following triggers are supported: `create`, `release`, `push` and `workflow_dispatch`, as recommended by the [SLSA specifications](https://github.com/slsa-framework/github-actions-buildtypes/tree/main/workflow/v1#description).
 
 ### TRW inputs
 

--- a/BYOB.md
+++ b/BYOB.md
@@ -58,7 +58,7 @@ The example snippet shows the invocation of a builder with path `.github/workflo
 
 ### Tool Repository
 
-This is the tool repository hosting the builder invoked by PWs. The repository contains two components:
+This is the tool repository hosting the builder invoked by PWs. The tool repository MUST be public. The repository contains two components:
 
 #### Tool Reusable Workflow (TRW)
 

--- a/BYOB.md
+++ b/BYOB.md
@@ -121,6 +121,7 @@ you have an issue related to any other triggers please submit a
 [`release`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
 [`push`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
 [`workflow_dispatch`]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+
 ### TRW inputs
 
 The first step for our integration is to create our TRW file and define its inputs. The inputs should mirror those of the existing Action above that we want to make SLSA compliant.


### PR DESCRIPTION
Due to https://github.com/actions/runner/issues/2274, we fetch the TRW workflow so it must be public. The GITHUB_TOKEN only lets us read private project repos, not the TRW rep.