### PR TITLE
[chore][bazel] use secure-folder-upload and temp dir

### DIFF
--- a/internal/builders/bazel/action.yml
+++ b/internal/builders/bazel/action.yml
@@ -76,12 +76,10 @@ runs:
     # TODO(#2276): Use secure upload folder Action
     - name: Generate Artifacts
       id: generate-artifacts
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v1.7.0
       with:
         name: "${{ steps.rng.outputs.random }}-binaries"
-        path: "./binaries" # path-to-artifact(s)
-        if-no-files-found: error
-        retention-days: 5
+        path: "./bazel_builder_binaries_to_upload_to_gh" # path-to-artifact(s)
 
     - name: Echo statement
       id: confirm

--- a/internal/builders/bazel/action.yml
+++ b/internal/builders/bazel/action.yml
@@ -73,7 +73,6 @@ runs:
       id: rng
       uses: slsa-framework/slsa-github-generator/.github/actions/rng@main
 
-    # TODO(#2276): Use secure upload folder Action
     - name: Generate Artifacts
       id: generate-artifacts
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v1.7.0

--- a/internal/builders/bazel/build.sh
+++ b/internal/builders/bazel/build.sh
@@ -16,7 +16,6 @@
 
 set -euo pipefail
 
-# TODO(Issue #2331): switch copy to binaries to a temp dir
 mkdir bazel_builder_binaries_to_upload_to_gh
 
 # Transfer flags and targets to their respective arrays
@@ -102,7 +101,7 @@ for curr_target in "${!targets_set[@]}"; do
     # Get the absolute path to output of Java JAR artifact.
     bazel_generated=$(bazel cquery --output=starlark --starlark:expr="'\n'.join([f.path for f in target.files.to_list()])" "$curr_target" 2>/dev/null)
 
-    # Copy JAR to artifact-specific dir in ./binaries and remove symbolic links.
+    # Copy JAR to artifact-specific dir in ./bazel_builder_binaries_to_upload_to_gh and remove symbolic links.
     file="$bazel_generated"
     cp -Lr "$file" "./bazel_builder_binaries_to_upload_to_gh/$run_script_name"
     

--- a/internal/builders/bazel/generate-layout.sh
+++ b/internal/builders/bazel/generate-layout.sh
@@ -19,11 +19,11 @@ set -euo pipefail
 # "version" and "attestations" fields:
 echo -e -n "{\n  \"version\": 1,\n  \"attestations\": [" >> "$SLSA_OUTPUTS_ARTIFACTS_FILE"
 
-num_binary_files=$(find ./binaries -type f | wc -l)
+num_binary_files=$(find ./bazel_builder_binaries_to_upload_to_gh -type f | wc -l)
 counter=1
 
 # Add one attestation per binary:
-find ./binaries -type f -print0 | while read -r -d $'\0' fname
+find ./bazel_builder_binaries_to_upload_to_gh -type f -print0 | while read -r -d $'\0' fname
 do
     bn=$(basename -- "$fname")
     hash=$(sha256sum "$fname" | awk '{print $1}')


### PR DESCRIPTION
closes #2276 
closes #2331 

This switches the folder upload from the actions/upload-artifact to our secure-upload-folder @ v1.7.0.

This also strengthens the name of the folder that is uploaded to avoid collisions. Since the path to folder cannot be in /tmp with the secure-upload-folder, the name of the folder being upload was changed from `binaries` to `bazel_builder_binaries_to_upload_to_gh` to avoid any potential name collisions and be able to utilize the secure-upload-folder action.