### PR TITLE
fix: fail if large file sha256 does not match

### DIFF
--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -111,6 +111,7 @@ runs:
         echo "computed hash is $UNTRUSTED_COMPUTED_HASH"
         if [[ "$UNTRUSTED_COMPUTED_HASH" != "$UNTRUSTED_EXPECTED_HASH" ]]; then
           echo "hashes do not match"
+          rm -rf "${TRUSTED_PATH}"
           exit -2
         fi
         echo "hashes match"

--- a/.github/actions/secure-download-folder/action.yml
+++ b/.github/actions/secure-download-folder/action.yml
@@ -63,6 +63,7 @@ runs:
         echo "computed hash is ${UNTRUSTED_COMPUTED_HASH}"
         if [[ "${UNTRUSTED_COMPUTED_HASH}" != "${UNTRUSTED_EXPECTED_HASH}" ]]; then
           echo "hashes do not match"
+          rm -rf "${TRUSTED_FOLDER}"
           exit -2
         fi
         echo "hashes match"

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -193,6 +193,7 @@ jobs:
           echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
 
       - name: Download subjects file
+        id: download-file
         continue-on-error: true
         if: inputs.base64-subjects-as-file != ''
         uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v1.8.0-rc.0
@@ -202,6 +203,7 @@ jobs:
           sha256: "${{ steps.metadata.outputs.sha256 }}"
 
       - name: Create subject file
+        id: create-file
         continue-on-error: true
         env:
           UNTRUSTED_SUBJECTS: "${{ inputs.base64-subjects }}"
@@ -259,7 +261,7 @@ jobs:
       - name: Final outcome
         id: final
         env:
-          SUCCESS: ${{ steps.generate-builder.outcome != 'failure' && steps.sign-prov.outcome != 'failure' && steps.upload-prov.outcome != 'failure' }}
+          SUCCESS: ${{ steps.generate-builder.outcome != 'failure' && steps.download-file.outcome != 'failure' && steps.create-file.outcome != 'failure' && steps.sign-prov.outcome != 'failure' && steps.upload-prov.outcome != 'failure' }}
         run: |
           set -euo pipefail
           echo "outcome=$([ "$SUCCESS" == "true" ] && echo "success" || echo "failure")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -261,7 +261,7 @@ jobs:
       - name: Final outcome
         id: final
         env:
-          SUCCESS: ${{ steps.generate-builder.outcome != 'failure' && steps.download-file.outcome != 'failure' && steps.create-file.outcome != 'failure' && steps.sign-prov.outcome != 'failure' && steps.upload-prov.outcome != 'failure' }}
+          SUCCESS: ${{ steps.generate-builder.outcome != 'failure' && steps.metadata.outcome != 'failure' && steps.download-file.outcome != 'failure' && steps.create-file.outcome != 'failure' && steps.sign-prov.outcome != 'failure' && steps.upload-prov.outcome != 'failure' }}
         run: |
           set -euo pipefail
           echo "outcome=$([ "$SUCCESS" == "true" ] && echo "success" || echo "failure")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
As part of https://github.com/slsa-framework/slsa-github-generator/pull/2365, we added support for large files.

We forgot to update the "success" computation. This means that even though the sha256 may differ from the expected, the job continues and we never record the failure status.

I fix this in the PR. I also delete the downloaded folder / artifact if the sha256 don't match, to avoid a similar problem in he future