### PR TITLE
feat: reduce package permissions in maven builder / publisher

### DIFF
--- a/.github/workflows/builder_maven_slsa3.yml
+++ b/.github/workflows/builder_maven_slsa3.yml
@@ -69,7 +69,6 @@ jobs:
       id-token: write # For signing.
       contents: read # For asset uploads.
       actions: read # For the entrypoint.
-      packages: write # To publish to GitHub packages.
     uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@main
     with:
       slsa-token: "${{ needs.slsa-setup.outputs.slsa-token }}"

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/internal/builders/maven/README.md
+++ b/internal/builders/maven/README.md
@@ -84,7 +84,6 @@ jobs:
       contents: write
       id-token: write
       actions: read
-      packages: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@main
     with:
       rekor-log-public: true

--- a/internal/builders/maven/README.md
+++ b/internal/builders/maven/README.md
@@ -81,10 +81,10 @@ env:
 jobs:
   build:
     permissions:
-      contents: write
       id-token: write
+      contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@main
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v1.7.0
     with:
       rekor-log-public: true
 ```

--- a/internal/builders/maven/README.md
+++ b/internal/builders/maven/README.md
@@ -96,12 +96,7 @@ You can also release artifacts to Maven Central by adding the following step to 
 ```yaml
   publish:
     needs: build
-    permissions:
-      contents: write
-      id-token: write
-      actions: read
-      packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/publish_maven.yml@main
+    uses: slsa-framework/slsa-github-generator/.github/workflows/publish_maven.yml@v1.7.0
     with:
       provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
       provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"


### PR DESCRIPTION
Write permissions are not needed for the lowperms delegator, so removing that from the Maven builder.