### PR TITLE
feat: Maven builder: Remove env vars from example

### DIFF
--- a/internal/builders/maven/README.md
+++ b/internal/builders/maven/README.md
@@ -75,9 +75,6 @@ on:
 
 permissions: read-all
 
-env:
-  GH_TOKEN: ${{ github.token }}
-  ISSUE_REPOSITORY: ${{ github.repository }}
 jobs:
   build:
     permissions:


### PR DESCRIPTION
Updates the Maven documentation to remove two env vars from the example PW.