### PR TITLE
feat: Keep ref in sync for Maven Actions

### DIFF
--- a/.github/workflows/scripts/pre-release/references.sh
+++ b/.github/workflows/scripts/pre-release/references.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 
 # Verify the tag has semver format.
 cd __EXAMPLE_PACKAGE__
+
 # shellcheck source=/dev/null
 source "./.github/workflows/scripts/e2e-utils.sh"
 major=$(version_major "$RELEASE_TAG")
@@ -84,7 +85,7 @@ fi
 # Verify the Maven Actions use the correct builder ref.
 results=$(
     find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f -print0 |
-        xargs -0 grep -Pn "ref:[ ]*(?!$RELEASE_TAG)" ||
+        xargs -0 grep -Pn "ref:(\s*(?!$RELEASE_TAG)[^\s]+)" ||
         true
 )
 if [[ "$results" != "" ]]; then

--- a/.github/workflows/scripts/pre-release/references.sh
+++ b/.github/workflows/scripts/pre-release/references.sh
@@ -81,6 +81,19 @@ if [[ "$results" != "" ]]; then
     exit 1
 fi
 
+# Verify the Maven Actions use the correct builder ref.
+results=$(
+    find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f -print0 |
+        xargs -0 grep -Pn "ref:[ ]*(?!$RELEASE_TAG)" ||
+        true
+)
+if [[ "$results" != "" ]]; then
+    echo "Some Maven Actions are referencing the builder at the incorrect tag \"$RELEASE_TAG\""
+    echo "$results"
+    exit 1
+fi
+
+
 if [[ "$RELEASE_TAG" =~ .*-rc\.[0-9]*$ ]]; then
     # don't check documentation for release candidates
     exit 0

--- a/.github/workflows/scripts/pre-submit.actions/references.sh
+++ b/.github/workflows/scripts/pre-submit.actions/references.sh
@@ -61,11 +61,11 @@ fi
 # Verify the Maven Actions use the correct builder ref.
 results=$(
     find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f -print0 |
-        xargs -0 grep -Pn "ref:[ ]*(?!main)" ||
+        xargs -0 grep -Pn "ref:(\s*(?!main)[^\s]+)" ||
         true
 )
 if [[ "$results" != "" ]]; then
-    echo "Some Maven Actions are referencing the builder at main"
+    echo "Some Maven Actions are not referencing the builder at main"
     echo "$results"
     exit 1
 fi

--- a/.github/workflows/scripts/pre-submit.actions/references.sh
+++ b/.github/workflows/scripts/pre-submit.actions/references.sh
@@ -57,3 +57,17 @@ if [[ "$results" != "" ]]; then
     echo "$results"
     exit 1
 fi
+
+# Verify the Maven Actions use the correct builder ref.
+results=$(
+    find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f -print0 |
+        xargs -0 grep -Pn "ref:[ ]*(?!main)" ||
+        true
+)
+if [[ "$results" != "" ]]; then
+    echo "Some Maven Actions are referencing the builder at main"
+    echo "$results"
+    exit 1
+fi
+
+

--- a/.github/workflows/scripts/pre-submit.actions/references.sh
+++ b/.github/workflows/scripts/pre-submit.actions/references.sh
@@ -36,7 +36,7 @@ fi
 
 # Verify our Actions are referenced at main in internal actions.
 results=$(
-    find .github/actions/ -maxdepth 2 -name '*.yaml' -o -name '*.yml' -type f -print0 \
+    find .github/actions/ -maxdepth 2 -name '*.yaml' -o -name '*.yml' -type f -print0 |
         xargs -0 grep -P "slsa-framework/slsa-github-generator/.*@(?!main)" ||
         true
 )

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -475,6 +475,7 @@ Update version references with the following command:
 
 ```shell
 find .github/workflows/ .github/actions/ actions/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\(.*\)@\(main\|v[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?\)/uses: slsa-framework\/slsa-github-generator\/\1@$BUILDER_TAG/"
+find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f | xargs sed -i "s/\(ref:[ ]*\)main/\1$BUILDER_TAG/"
 ```
 
 Likewise, update documentation with the following command:
@@ -504,6 +505,8 @@ Send a PR to reference the Actions at `@main`. You can use:
 
 ```shell
 find .github/workflows/ .github/actions/ actions/ -name '*.yaml' -o -name '*.yml' | xargs sed -i "s/uses: slsa-framework\/slsa-github-generator\/\(.*\)@${BUILDER_TAG}/uses: slsa-framework\/slsa-github-generator\/\1@main/"
+find actions/maven/ internal/builders/maven/ -name '*.yaml' -o -name '*.yml' -type f | xargs sed -i "s/\(ref:[ ]*\)$BUILDER_TAG/\1main/"
+
 ```
 
 ### Update verifier

--- a/actions/maven/publish/action.yml
+++ b/actions/maven/publish/action.yml
@@ -76,7 +76,7 @@ runs:
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
       with:
         repository: slsa-framework/slsa-github-generator
-        ref: v1.8.0
+        ref: main
         path: __BUILDER_CHECKOUT_DIR__
 
     - name: Publish to the Maven Central Repository

--- a/internal/builders/maven/action.yml
+++ b/internal/builders/maven/action.yml
@@ -62,7 +62,7 @@ runs:
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@main
       with:
         repository: slsa-framework/slsa-github-generator
-        ref: v1.8.0
+        ref: main
         path: __BUILDER_CHECKOUT_DIR__
     - name: Run mvn package
       shell: bash


### PR DESCRIPTION
closes https://github.com/slsa-framework/slsa-github-generator/issues/2508

We need to keep in sync the checkout of the slsa-github-generator repo