### PR TITLE
feat: docker input for Bazel Builder and Rebuilder

### DIFF
--- a/.github/workflows/builder_bazel_slsa3.yml
+++ b/.github/workflows/builder_bazel_slsa3.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: ""
+      docker-image:
+        description: "Docker Image for build environment to run on"
+        required: false
+        type: string
+        default: ""
       needs-runfiles:
         description: >
           A boolean input that if true will package the artifact's runfiles along with the artifact.
@@ -75,6 +80,19 @@ on:
           When run on a `pull_request` trigger, attestations are not signed and have an ".intoto" extension.
           When run on other triggers, attestations are signed and have an "intoto.sigstore" extension.
         value: ${{ jobs.slsa-run.outputs.attestations-download-name }}
+
+      provenance-download-sha256:
+        description: >
+          The sha256 digest of the attestations.
+
+          Users should verify the download against this digest to prevent tampering.
+        value: ${{ jobs.slsa-run.outputs.attestations-download-sha256 }}
+
+      binaries-download-name:
+        description: >
+          The name of the folder containing the built artifacts. There is a random hash at the
+          beginning of it in form <hash>-binaries to avoid collisions.
+        value: ${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).binaries-download-name }}
 
 jobs:
   slsa-setup:

--- a/internal/builders/bazel/action.yml
+++ b/internal/builders/bazel/action.yml
@@ -41,6 +41,12 @@ inputs:
   slsa-workflow-secret14: {}
   slsa-workflow-secret15: {}
 
+outputs:
+  binaries-download-name:
+    description: "The name of binaries folder to download"
+    # NOTE: This is an "untrusted" value returned from the build.
+    value: "${{ steps.rng.outputs.random }}-binaries"
+
 runs:
   using: "composite"
   steps:
@@ -52,13 +58,47 @@ runs:
       uses: bazelbuild/setup-bazelisk@95c9bf48d0c570bb3e28e57108f3450cd67c1a44 # v2.0.0
 
     - name: Setup Java
+      if: ${{ fromJson(inputs.slsa-workflow-inputs).includes-java }} == 'true'
       id: java
       uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
       with:
         distribution: "${{ fromJson(inputs.slsa-workflow-inputs).user-java-distribution }}"
         java-version: "${{ fromJson(inputs.slsa-workflow-inputs).user-java-version }}"
 
+    - name: Check for Docker Image
+      id: docker
+      shell: bash
+      run: |
+        if [[ -z "${{ fromJson(inputs.slsa-workflow-inputs).docker-image }}" ]]
+        then
+          echo "No Docker Image provided. Will build without."
+          echo "USE_DOCKER=false" >> $GITHUB_ENV
+        else
+          echo "Docker image provided. Running build on Docker Image."
+          echo "USE_DOCKER=true" >> $GITHUB_ENV
+        fi
+
+    - name: Build on Docker Image
+      if: env.USE_DOCKER == 'true'
+      env:
+        TARGETS: ${{ fromJson(inputs.slsa-workflow-inputs).targets }}
+        FLAGS: ${{ fromJson(inputs.slsa-workflow-inputs).flags }}
+        NEEDS_RUNFILES: ${{ fromJson(inputs.slsa-workflow-inputs).needs-runfiles }}
+        INCLUDES_JAVA: ${{ fromJson(inputs.slsa-workflow-inputs).includes-java }}
+        DOCKER_IMAGE: ${{ fromJson(inputs.slsa-workflow-inputs).docker-image }}
+      shell: bash
+      run: |
+        export TARGETS
+        export FLAGS
+        export NEEDS_RUNFILES
+        export INCLUDES_JAVA
+
+        docker pull $DOCKER_IMAGE
+        curr_dir=$(basename "$(pwd)")
+        docker run --rm --env TARGETS=${TARGETS} --env FLAGS=${FLAGS} --env NEEDS_RUNFILES=${NEEDS_RUNFILES} --env INCLUDES_JAVA=${INCLUDES_JAVA} -v $PWD/../:/src -w /src $DOCKER_IMAGE /bin/sh -c "ls && tree && cd $curr_dir && ls && tree && ./../__TOOL_ACTION_DIR__/build.sh"
+
     - id: build
+      if: env.USE_DOCKER == 'false'
       env:
         TARGETS: ${{ fromJson(inputs.slsa-workflow-inputs).targets }}
         FLAGS: ${{ fromJson(inputs.slsa-workflow-inputs).flags }}

--- a/internal/builders/bazel/rebuilder.sh
+++ b/internal/builders/bazel/rebuilder.sh
@@ -1,0 +1,490 @@
+#!/bin/bash
+#
+# Copyright 2023 SLSA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: -u not set to check for empty variables from parse arguments function.
+set -eo pipefail
+
+# Disabled to stop triggering warnings about color env vars.
+
+# This directory is where the rebuilt artifacts will be stored. It is made upon
+# running the rebuilder. The long name is to avoid potential collisions.
+rebuilt_artifacts_dir="rebuilt_artifacts_0ffe97cd2693d6608f5a787151950ed8"
+mkdir $rebuilt_artifacts_dir
+
+################################################
+#                                              #
+#            Color Code Env Vars               #
+#                                              #
+################################################
+
+RESET="\033[0m"
+BOLD="\033[1m"
+RED="\033[1;31m"
+LIGHT_RED="\033[0;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+BLUE="\033[1;34m"
+CYAN="\033[1;36m"
+MAGENTA="\033[1;35m"
+PURPLE="\033[1;35m"
+BOLD_RED_BG="\033[1;41m"
+UNDERLINE="\033[4m"
+
+################################################
+#                                              #
+#           To Output Styled Progress          #
+#                                              #
+################################################
+
+TYPE_SPEED=0.02
+function type_writer {
+  text="$1"
+
+  for (( i=0; i<${#text}; i++ )); do
+    echo -n "${text:$i:1}"
+    sleep $TYPE_SPEED
+  done
+  echo ""
+}
+
+################################################
+#                                              #
+#             Process Arguments                #
+#                                              #
+################################################
+
+# For later - after rebuild - to cd into binaries folder to obtain artifacts.
+# The long name is to avoid potential collisions.
+binaries_dir="bazel_builder_binaries_to_upload_to_gh_7bc972367cb286b7f36ab4457f06e369"
+
+# Boolean that decides whether to use the slsa-verifier in addition to rebuild.
+verify=0
+
+# Boolean to trigger verbose version of Rebuilder.
+verbose=0
+
+# Boolean to trigger cleanup upon completion or failure.
+cleanup=0
+
+# Outputs the usage of the Rebuilder script for the two modes:
+# 1) Verify and Rebuild
+# 2) Rebuild only
+function usage() {
+  if [[ $verify ]]
+  then
+    # Disabled to stop triggering warnings about color env vars.
+    # shellcheck disable=SC2059
+    printf "${RED}[ERROR] ${LIGHT_RED}Wrong usage. Usage to verify AND rebuild artifact:${RESET}\n"
+    printf "${CYAN}Usage: %s ${YELLOW}--artifact_path${RESET} <path> ${YELLOW}--prov_path${RESET} <path> ${YELLOW}--source_uri${RESET} <uri> ${YELLOW}--builder_id${RESET} <id> ${MAGENTA}[--docker_image]${RESET} <image> ${MAGENTA}[--verify]${RESET}\n" "$0"
+    printf "${RED}[ERROR] ${LIGHT_RED}Wrong usage. Usage to ONLY rebuild the artifact:${RESET}\n"
+    printf "${CYAN}Usage: %s ${YELLOW}--artifact_path${RESET} <path> ${YELLOW}--prov_path${RESET} <path> ${MAGENTA}[--docker_image]${RESET} <image>\n" "$0"
+  else
+    # shellcheck disable=SC2059
+    printf "${RED}[ERROR] ${LIGHT_RED}Wrong usage. Usage to ONLY rebuild the artifact:${RESET}\n"
+    printf "${CYAN}Usage: %s ${YELLOW}--artifact_path${RESET} <path> ${YELLOW}--prov_path${RESET} <path> ${MAGENTA}[--docker_image]${RESET} <image>\n" "$0"
+    printf "${RED}[ERROR] ${LIGHT_RED}Wrong usage. Usage to verify AND rebuild artifact:${RESET}\n"
+    printf "${CYAN}Usage: %s ${YELLOW}--artifact_path${RESET} <path> ${YELLOW}--prov_path${RESET} <path> ${YELLOW}--source_uri${RESET} <uri> ${YELLOW}--builder_id${RESET} <id> ${MAGENTA}[--docker_image]${RESET} <image> ${MAGENTA}[--verify]${RESET}\n" "$0"
+  fi
+}
+
+# Processes an argument for the script. Returns 0 if the given argument
+# was recognized as an argument for this script, and 1 if it was not.
+function process_argument() {
+  case "$1" in
+    --artifact_path=*) artifact_path="${1#--artifact_path=}" ;;
+    --prov_path=*) prov_path="${1#--prov_path=}" ;;
+    --source_uri=*) source_uri="${1#--source_uri=}" ;;
+    --builder_id=*) builder_id="${1#--builder_id=}" ;;
+    --docker_image=*) docker_image="${1#--docker_image=}" ;;
+    --verify) verify=1 ;;
+    --verbose) verbose=1 ;;
+    --cleanup) cleanup=1 ;;
+
+    *)
+      return 1 ;;
+  esac
+  return 0
+}
+
+# This function is will clean up built directories off after error.
+function cleanup() {
+  # If the cleanup flag is specified, remove created directories.
+  if [[ $cleanup -eq 1 ]]
+  then
+    type_writer "🧹---> Cleaning up $rebuilt_artifacts_dir..."
+    rm -rf $rebuilt_artifacts_dir
+
+    type_writer "🧹---> Cleaning up $repo_name..."
+    sudo rm -rf "$repo_name"
+
+    type_writer "🧹---> Cleaning up slsa-verifier..."
+    sudo rm -rf slsa-verifier
+  fi
+}
+
+# Parse arguments sequentially to check for unrecognized arguments
+for ARG in "$@"; do
+  returnValue=$?
+  process_argument "$ARG"
+  if [[ ! ($returnValue) ]]
+  then
+    my_arg="$ARG"
+    printf "${RED}[ERROR] ${LIGHT_RED}%s is unrecognized${RESET}\n" "$my_arg"
+    usage
+    exit 1
+  fi
+done
+
+################################################
+#                                              #
+#        Check Usage and Output Verbose        #
+#                                              #
+################################################
+
+# Check if mandatory arguments for rebuild are not empty
+if [ -z "$artifact_path" ]; then
+  printf "${RED}[ERROR] ${LIGHT_RED}Mandatory argument for rebuild, --artifact_path, is missing or empty${RESET}\n"
+  usage
+  exit 1
+fi
+
+if [ -z "$prov_path" ]; then
+  printf "${RED}[ERROR] ${LIGHT_RED}Mandatory argument for rebuild, --prov_path, is missing or empty${RESET}\n"
+  usage
+  exit 1
+fi
+
+if [ -z "$source_uri" ]; then
+  printf "${RED}[ERROR] ${LIGHT_RED}Mandatory argument for rebuild, --source_uri, is missing or empty${RESET}\n"
+  usage
+  exit 1
+fi
+
+# Check if mandatory arguments for verification are not empty
+if [[ $verify -eq 1 && ( -z "$source_uri" || -z "$builder_id" ) ]]
+then
+  printf "${RED}[ERROR] ${LIGHT_RED}Mandatory arguments for verification missing or empty${RESET}\n"
+  usage
+  exit 1
+fi
+
+# Print received arguments (optional)
+if [[ $verbose -eq 1 ]]
+then
+  printf "${BLUE}✔ Input Arguments Received:${RESET}\n"
+  printf "${CYAN}artifact_path: ${GREEN}%s${RESET}\n" "$artifact_path"
+  printf "${CYAN}prov_path: ${GREEN}%s${RESET}\n" "$prov_path"
+  printf "${CYAN}source_uri: ${GREEN}%s${RESET}\n" "$source_uri"
+
+  if [ -n "$builder_id" ]; then
+    printf "${CYAN}builder_id: ${GREEN}%s${RESET}\n" "$builder_id"
+  fi
+
+  if [ -n "$docker_image" ]; then
+    printf "${CYAN}docker_image: ${GREEN}%s${RESET}\n" "$docker_image"
+  fi
+
+  printf "${CYAN}verify: ${GREEN}%s${RESET}\n" "$verify"
+  printf "${CYAN}verbose: ${GREEN}%s${RESET}\n" "$verbose"
+  printf "${CYAN}cleanup: ${GREEN}%s${RESET}\n" "$cleanup"
+  echo ""
+fi
+
+################################################
+#                                              #
+#           Use Verifier (if --verify)         #
+#                                              #
+################################################
+
+if [[ $verify -eq 1 ]]
+then
+  # Clone the slsa-verifier repository
+  if [ -d "slsa-verifier" ]; then
+    type_writer "📁---> The slsa-verifier repository is already cloned."
+    type_writer "⚠️---> To verify please remove the collision and try again"
+    exit 1
+  else
+    printf "${CYAN}====================================================${RESET}\n"
+    type_writer "📥---> The slsa-verifier repository is not cloned. Cloning..."
+    git clone https://github.com/enteraga6/slsa-verifier
+  fi
+
+  # Change directory to the slsa-verifier directory
+  cd slsa-verifier
+
+  # Run SLSA Verifier on user inputs
+  # write if builder id then this if not include builder id then other command
+  # this is for once the non-compulsory feature gets merged.
+  go run ./cli/slsa-verifier/ verify-artifact ../"$artifact_path" --provenance-path ../"$prov_path" --source-uri "$source_uri" --builder-id "$builder_id"
+
+  cd ..
+  printf "${CYAN}====================================================${RESET}\n"
+  echo ""
+fi
+
+# Compute the original checksum of the artifact to compare with Rebuilt.
+orig_checksum=$(sha256sum "$artifact_path" | awk '{ print $1 }')
+
+################################################
+#                                              #
+#               Parse Provenance               #
+#                                              #
+################################################
+
+# Associative Array to store the inputs to the GH workflow in key:value form
+declare -A data
+
+# Extract the inputs and put them in data map where the key is the workflow input,
+# and the value is the value that the user inputted. Pipe value to @text, to deal with booleans.
+while IFS='=' read -r key value; do
+    data["$key"]="$value"
+done < <(cat "$prov_path" | jq -r '.dsseEnvelope.payload' | base64 -d | jq -r '.predicate.buildDefinition.externalParameters.inputs | to_entries | .[] | .key + "=" + (.value | @text)')
+
+# Todo: Style Env Vars Later
+
+if [[ $verbose -eq 1 ]]
+then
+  printf "${PURPLE}✔ Arguments Parsed from Provenance:${RESET}\n"
+  for key in "${!data[@]}"
+  do
+      printf "${MAGENTA}$key: ${GREEN}%s${RESET}\n" "${data[$key]}"
+  done
+  echo ""
+fi
+
+################################################
+#                                              #
+#                 Setup ENV Vars               #
+#                                              #
+################################################
+
+# The name map will convert and export the key strings of inputs to
+# match with the environment variables of the Bazel Builder build.sh
+declare -A name_mapping
+name_mapping["targets"]="TARGETS"
+name_mapping["flags"]="FLAGS"
+name_mapping["docker-image"]="DOCKER_IMAGE"
+
+# Note: These boolean inputs are now dealed with as strings
+name_mapping["includes-java"]="INCLUDES_JAVA"
+name_mapping["needs-runfiles"]="NEEDS_RUNFILES"
+
+# Export the inputs for later use
+for key in "${!data[@]}"; do
+    # Check to see if the key is in name map before export as env var.
+    if [[ ${name_mapping[$key]+_} ]]; then
+        export "${name_mapping[$key]}"="${data[$key]}"
+    fi
+done
+
+################################################
+#                                              #
+#            Clone Repo to Rebuild             #
+#                                              #
+################################################
+
+repo_name=$(basename "$source_uri")
+# Clone the source_uri repository to begin rebuild process
+if [ -d "$repo_name" ]; then
+  printf "${CYAN}====================================================${RESET}\n"
+  type_writer "📁---> Source repository appears already."
+  type_writer "⚠️---> To run rebuilder, fix collision by removing directory with name of $repo_name."
+  exit 1
+else
+  printf "${CYAN}====================================================${RESET}\n"
+  type_writer "🐑---> Cloning the source repository..."
+  echo ""
+  git clone https://"$source_uri"
+  printf "${CYAN}====================================================${RESET}\n"
+  echo ""
+fi
+
+# Enter the Repo
+cd "$repo_name"
+
+# Check to see if JAVA_HOME is set then empty to
+# avoid triggering unbound variable error.
+if [[ "${INCLUDES_JAVA}" == "true" ]]
+then
+    if [[ ! -v JAVA_HOME || -z "${JAVA_HOME}" ]]
+    then
+        # if JAVA_HOME is empty, set to jdk bin path from $(which java)
+        if java_path=$(which java); then
+            JAVA_HOME="$(dirname "$(dirname "${java_path}")")"
+            export JAVA_HOME
+        # JAVA_HOME cannot be set automatically
+        else
+            echo "JAVA_HOME cannot be set automatically. Check PATH."
+        fi
+    else
+        echo "JAVA_HOME already set to ${JAVA_HOME}"
+    fi
+fi
+
+################################################
+#                                              #
+#              Rebuild the Artifacts           #
+#                                              #
+################################################
+
+echo ""
+printf "${CYAN}======================================================${RESET}\n"
+printf "${CYAN}|${RESET}${YELLOW}${UNDERLINE}        🔨  Starting the Rebuild Process  🔨        ${RESET}${CYAN}|${RESET}\n"
+printf "${CYAN}======================================================${RESET}\n"
+
+# Conditionals for docker images depend on if a Docker Image was use to build on Github.
+# If a Docker Image was not used to build on Github, then build locally. This is done to
+# ensure consistent build environment between both platforms.
+if [[ -n $DOCKER_IMAGE ]]
+then
+    cd -
+    sudo docker pull "$DOCKER_IMAGE"
+    echo ""
+    printf "${CYAN}====================================================${RESET}\n"
+    type_writer "🔨---> Rebuilding with Docker Image Environment..."    # Mount docker image on this directory as workdir to gain access to script env
+    printf "${CYAN}====================================================${RESET}\n"
+    echo ""
+
+    sudo docker run --env repo_name="$repo_name" --env TARGETS="${TARGETS}" --env FLAGS="${FLAGS}" --env NEEDS_RUNFILES="${NEEDS_RUNFILES}" --env INCLUDES_JAVA="${INCLUDES_JAVA}" --rm -v "$PWD":/workdir -w /workdir "$DOCKER_IMAGE" /bin/sh -c "cd $repo_name && ./../build.sh"
+    echo ""
+    printf "${CYAN}=============================================${RESET}\n"
+    printf "${CYAN}|${RESET}${YELLOW}${UNDERLINE}        ✅  Artifacts Rebuilt! ✅          ${RESET}${CYAN}|${RESET}\n"
+    printf "${CYAN}=============================================${RESET}\n"
+    echo ""
+else
+    if [[ -n "$docker_image" ]]
+    then
+      # Warning message for the users if their artifact was not built with a Docker Image, but a Docker Image was provided at command.
+      printf "${RED}[Warning] ${LIGHT_RED}Docker Image, %s, provided, but artifact was not originally built on Docker Image${RESET}\n" "$docker_image"
+    else
+      echo "" # This is just for style.
+    fi
+
+    # Run the build script locally without a docker image.
+    printf "${CYAN}=============================================${RESET}\n"
+    type_writer "💻---> Rebuilding with local environment..."
+    printf "${CYAN}=============================================${RESET}\n"
+    echo ""
+
+    # shellcheck source=../build.sh
+    source ../build.sh
+    echo ""
+    printf "${CYAN}=============================================${RESET}\n"
+    printf "${CYAN}|${RESET}${YELLOW}${UNDERLINE}        ✅  Artifacts Rebuilt! ✅          ${RESET}${CYAN}|${RESET}\n"
+    printf "${CYAN}=============================================${RESET}\n"
+    echo ""
+fi
+
+# To avoid unbound variable after build script which sets -euo.
+set +u
+
+# If Docker Image was used to build on Github, we need to cd into repo
+# to access the binaries directory.
+if [[ -n $DOCKER_IMAGE ]]
+then
+  cd "$repo_name"
+fi
+
+################################################
+#                                              #
+#               Copy the Artifact              #
+#                                              #
+################################################
+
+# Obtain the name of the artifact
+if [[ $artifact_path == */* ]]
+then
+    artifact_name=$(basename "$artifact_path")
+else
+    artifact_name=$artifact_path
+fi
+
+rebuilt_checksum=""
+unset rebuilt_checksum # Makes sure it is empty before assigning.
+
+# IF there are runfiles, the directory structure will be different.
+# The binaries folder contains different directories for the its artifacts and
+# the artifacts runfiles. Obtain the rebuilt binaries and copy them to the
+# path at root before cleaning up and deleting the repo.
+if [[ "$artifact_name" == *"_deploy.jar"* ]]
+then
+      # Uses _deploy.jar as a field seperator and grabs the field before it.
+      # Directory of Java artifacts is same as run script name.
+      run_script_name=$(echo "$artifact_name" | awk -F'_deploy.jar' '{print $1}')
+      cd $binaries_dir/
+      rebuilt_checksum=$(sha256sum ./"$run_script_name"/"$artifact_name" | awk '{ print $1 }')
+
+      # Copy the entire directory, including the run script.
+      cp -R ./"$run_script_name" ./../../"$rebuilt_artifacts_dir"/
+else
+    if [[ "${NEEDS_RUNFILES}" == "true" ]]
+    then
+        # For non-java targets with runfiles.
+      cd $binaries_dir/
+      rebuilt_checksum=$(sha256sum ./"$artifact_name"/"$artifact_name" | awk '{ print $1 }')
+
+      # Copy entire directory, including the runfiles.
+      cp -R ./"$artifact_name" ./../../"$rebuilt_artifacts_dir"/
+    else
+    # For files withouts runfiles.
+    cd $binaries_dir
+    rebuilt_checksum=$(sha256sum "$artifact_name" | awk '{ print $1 }')
+
+    cp "$artifact_name" ./../../$rebuilt_artifacts_dir/
+    fi
+fi
+
+################################################
+#                                              #
+#       Check Build for Reproducibility        #
+#                                              #
+################################################
+
+if [[ "$orig_checksum" == "$rebuilt_checksum" ]]
+then
+    printf "${GREEN}Checksum is the ${BOLD}${UNDERLINE}same${RESET}${GREEN} for the original and rebuilt artifact!${RESET}\n"
+    printf "${GREEN}✅ This build is ${BOLD}${UNDERLINE}reproducible!${RESET} ✅ \n"
+    echo ""
+    printf "${GREEN}%s${RESET} = Original Checksum${RESET}\n" "$orig_checksum"
+    printf "${GREEN}%s${RESET} = Rebuilt Checksum${RESET}\n" "$rebuilt_checksum"
+    echo ""
+else
+    printf "${BOLD_RED_BG}Checksum is ${BOLD}${UNDERLINE}NOT${RESET}${BOLD_RED_BG} the same for the original and rebuilt artifact!${RESET}\n"
+    printf "${BOLD_RED_BG}        ⚠️  This build was ${BOLD}${UNDERLINE}NOT${RESET}${BOLD_RED_BG} able to be reproduced! ⚠️         ${RESET}\n"
+    echo ""
+    printf "${RED}%s${RESET} = Original Checksum\n" "$orig_checksum"
+    printf "${RED}%s${RESET} = Rebuilt Checksum\n" "$rebuilt_checksum"
+    echo ""
+fi
+
+
+if [[ cleanup -eq 1 ]]
+then
+
+  # If there are runfiles or if the artifacts are Java, then each artifact
+  # has its own directory, so you need to exit out of it first.
+  if [[ "${NEEDS_RUNFILES}" == "true" || "${INCLUDES_JAVA}" == "true" ]]
+  then
+    cd ..
+  fi
+
+  # Current position is bazel_builder_dir/$repo_name/$binaries_dir,
+  # and to clean up need to be in /bazel.
+  cd ../..
+
+  # Now cleanup of verifier and cloned $repo_name.
+  cleanup
+fi


### PR DESCRIPTION
closes #2377 

/cc: @mihaimaruseac @laurentsimon 

Adds a feature to input a published docker image to build on top of for the Bazel Builder. Building on top of a docker image allows for reproducible build capabilities. There are now two paths for the Bazel Builder to build: using the docker image, and without, which it was doing before. Both utilize the same build script.

To check, the rebuilder will parse the arguments from the provided provenance and use the attest build process to rebuild the artifact. After the rebuild, it will compare the checksums of the provided artifact at command line to verify if the build was successfully reproducible. The rebuilder can handle every type of build that the original Github Actions Bazel Builder can, with different logic for the three main types of artifacts: java targets, targets with runfiles, and targets without runfiles.

The rebuilder does not have to build on a Docker Image. If the `docker_image` flag is not populated, it will build locally on the machine. If the `docker_image` flag is populated, but the artifact was not built on a docker image (concurred from the provenance parsing), it will also build locally and a warning will show.

There is also a verbose flag for a user to see their inputs and the arguments that were parsed out of the provenance.

The rebuilder has flags for verifying the artifact and provenance before rebuilding. 

Two main repos are cloned: the source repo specifed as an input to the rebuilder via `--source_uri`, and slsa-verifier if `--verify flag` is present. There are two main usages, rebuilder only or slsa-verifier + rebuilder, which requires the extra input of the `builder_id `flag for the verifier.

After completion, the rebuilt artifact will be in a rebuilt artifact directory which has a long random hash at the end to avoid collisions. Something to note is that the entire build process gets repeated since the build arguments are parsed from the provenance. So, if the user builds every target on the GHA, every target will be rebuilt as well, but only the specified target will be copied to the rebuilt artifact directory. If the user only cares about checking the checksums, they can specify the `--cleanup` flag which will remove the rebuilt artifact dir, the source repo dir, and the slsa-verifier dir, after the rebuilding process is complete.

Documentation on the rebuilder will come in a subsequent PR.

Additionally in this PR, the Bazel Builder workflow has been equipped with more outputs. Added is the sha256 of provenance, and the previously missing name of the binaries directory which will allow users to use this workflow for releases.

Note: I use colorful printf statements that trigger shellcheck. Instead of writing # shellcheck disable=SC2059 over each one I let the warnings persist. I made this decision because they are a lot of printf statements. Also, the warnings are about the environment variables i hardcoded for the colors, not any other environment variable. All other environment variables have been dealt with as SC2059 suggests. [SC2059](https://www.shellcheck.net/wiki/SC2059) suggests ignoring the warning with a directive, but that would have cluttered the code.