### PR TITLE
chore: make build dirs of java builders unique

### DIFF
--- a/.github/workflows/builder_gradle_slsa3.yml
+++ b/.github/workflows/builder_gradle_slsa3.yml
@@ -50,17 +50,17 @@ on:
         description: "The sha256 of the provenance attestation uploaded to the workflow run."
         value: "${{ jobs.slsa-run.outputs.attestations-download-sha256 }}"
 
-      target-download-name:
+      build-download-name:
         description: "The name of the build directory uploaded to the workflow run."
         # NOTE: This is an "untrusted" value returned from the build. Technically
         # the build could provide a build directory that doesn't match the
         # provenance but it would fail validation.
-        value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).package-download-name }}"
+        value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).build-download-name }}"
 
-      target-download-sha256:
-        description: "The sha256 of the target uploaded to the workflow run."
+      build-download-sha256:
+        description: "The sha256 of the build directory uploaded to the workflow run."
         # NOTE: This is an "untrusted" value returned from the build.
-        value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).target-download-sha256 }}"
+        value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).build-download-sha256 }}"
 jobs:
   slsa-setup:
     permissions:

--- a/.github/workflows/builder_gradle_slsa3.yml
+++ b/.github/workflows/builder_gradle_slsa3.yml
@@ -50,6 +50,13 @@ on:
         description: "The sha256 of the provenance attestation uploaded to the workflow run."
         value: "${{ jobs.slsa-run.outputs.attestations-download-sha256 }}"
 
+      target-download-name:
+        description: "The name of the build directory uploaded to the workflow run."
+        # NOTE: This is an "untrusted" value returned from the build. Technically
+        # the build could provide a build directory that doesn't match the
+        # provenance but it would fail validation.
+        value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).package-download-name }}"
+
       target-download-sha256:
         description: "The sha256 of the target uploaded to the workflow run."
         # NOTE: This is an "untrusted" value returned from the build.

--- a/.github/workflows/builder_maven_slsa3.yml
+++ b/.github/workflows/builder_maven_slsa3.yml
@@ -47,6 +47,13 @@ on:
         description: "The sha256 of the provenance attestation uploaded to the workflow run."
         value: "${{ jobs.slsa-run.outputs.attestations-download-sha256 }}"
 
+      target-download-name:
+        description: "The name of the target directory uploaded to the workflow run."
+        # NOTE: This is an "untrusted" value returned from the build. Technically
+        # the build could provide a target directory that doesn't match the
+        # provenance but it would fail validation.
+        value: ${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).package-download-name }}
+
       target-download-sha256:
         description: "The sha256 of the target uploaded to the workflow run."
         value: "${{ fromJSON(jobs.slsa-run.outputs.build-artifacts-outputs).target-download-sha256 }}"

--- a/actions/gradle/publish/README.md
+++ b/actions/gradle/publish/README.md
@@ -260,6 +260,7 @@ publish:
       with:
         provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
         provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"
+        target-download-name: "${{ needs.build.outputs.target-download-name }}"
         target-download-sha256: "${{ needs.build.outputs.target-download-sha256 }}"
         maven-username: ${{ secrets.OSSRH_USERNAME }}
         maven-password: ${{ secrets.OSSRH_PASSWORD }}

--- a/actions/gradle/publish/README.md
+++ b/actions/gradle/publish/README.md
@@ -260,8 +260,8 @@ publish:
       with:
         provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
         provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"
-        target-download-name: "${{ needs.build.outputs.target-download-name }}"
-        target-download-sha256: "${{ needs.build.outputs.target-download-sha256 }}"
+        build-download-name: "${{ needs.build.outputs.build-download-name }}"
+        build-download-sha256: "${{ needs.build.outputs.build-download-sha256 }}"
         maven-username: ${{ secrets.OSSRH_USERNAME }}
         maven-password: ${{ secrets.OSSRH_PASSWORD }}
         gpg-key-pass: ${{ secrets.GPG_PASSPHRASE }}
@@ -269,7 +269,7 @@ publish:
         jdk-version: "17"
 ```
 
-Set the values of "maven-username", "maven-password", "gpg-key-pass" and " gpg-private-key" for your account. The parameters to `provenance-download-name`, `provenance-download-sha256` and `target-download-sha256` should not be changed.
+Set the values of "maven-username", "maven-password", "gpg-key-pass" and " gpg-private-key" for your account. The parameters to `provenance-download-name`, `provenance-download-sha256`, `target-download-name`, and `target-download-sha256` should not be changed.
 
 Once you trigger this workflow, your artifacts and provenance files will be added to a staging repository in Maven Central. You need to close the staging repository and then release:
 

--- a/actions/gradle/publish/action.yml
+++ b/actions/gradle/publish/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "The sha256 of the package provenance artifact."
     required: false
     type: string
+  target-download-name:
+    description: "The name of the build directory from the build action."
+    required: true
+    type: string
   target-download-sha256:
     description: "The sha256 of the target directory."
     required: true
@@ -71,7 +75,7 @@ runs:
     - name: Download the target dir
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@main
       with:
-        name: build
+        name: "${{ inputs.target-download-name }}"
         path: ./
         sha256: "${{ inputs.target-download-sha256 }}"
     - name: Upload to Maven Central
@@ -83,7 +87,10 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
         PROVENANCE: "build/libs/slsa-attestations/"
+        BUILD_DIR: "./${{ inputs.target-download-name }}"
       run: |
+        # Change name of downloaded build directory
+        mv "${BUILD_DIR}" ./build
         # Collect the provenance files into a subdirectory of "./build"
         mv "${SLSA_DIR}" ./build/libs/slsa-attestations
         # Import GPG signing key

--- a/actions/gradle/publish/action.yml
+++ b/actions/gradle/publish/action.yml
@@ -87,10 +87,7 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
         PROVENANCE: "build/libs/slsa-attestations/"
-        BUILD_DIR: "./${{ inputs.build-download-name }}"
       run: |
-        # Change name of downloaded build directory
-        mv "${BUILD_DIR}" ./build
         # Collect the provenance files into a subdirectory of "./build"
         mv "${SLSA_DIR}" ./build/libs/slsa-attestations
         # Import GPG signing key

--- a/actions/gradle/publish/action.yml
+++ b/actions/gradle/publish/action.yml
@@ -22,12 +22,12 @@ inputs:
     description: "The sha256 of the package provenance artifact."
     required: false
     type: string
-  target-download-name:
+  build-download-name:
     description: "The name of the build directory from the build action."
     required: true
     type: string
-  target-download-sha256:
-    description: "The sha256 of the target directory."
+  build-download-sha256:
+    description: "The sha256 of the build directory."
     required: true
     type: string
   jdk-version:
@@ -72,12 +72,12 @@ runs:
         path: ./
         sha256: "${{ inputs.provenance-download-sha256 }}"
 
-    - name: Download the target dir
+    - name: Download the build dir
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@main
       with:
-        name: "${{ inputs.target-download-name }}"
+        name: "${{ inputs.build-download-name }}"
         path: ./
-        sha256: "${{ inputs.target-download-sha256 }}"
+        sha256: "${{ inputs.build-download-sha256 }}"
     - name: Upload to Maven Central
       shell: bash
       env:
@@ -87,7 +87,7 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
         PROVENANCE: "build/libs/slsa-attestations/"
-        BUILD_DIR: "./${{ inputs.target-download-name }}"
+        BUILD_DIR: "./${{ inputs.build-download-name }}"
       run: |
         # Change name of downloaded build directory
         mv "${BUILD_DIR}" ./build

--- a/actions/maven/publish/README.md
+++ b/actions/maven/publish/README.md
@@ -49,6 +49,7 @@ publish:
       with:
         provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
         provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"
+        target-download-name: "${{ needs.build.outputs.target-download-name }}"
         target-download-sha256: "${{ needs.build.outputs.target-download-sha256 }}"
         maven-username: ${{ secrets.OSSRH_USERNAME }}
         maven-password: ${{ secrets.OSSRH_PASSWORD }}
@@ -56,7 +57,7 @@ publish:
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 ```
 
-Set the values of "maven-username", "maven-password", "gpg-key-pass" and " gpg-private-key" for your account. The parameters to `provenance-download-name`, `provenance-download-sha256` and `target-download-sha256` should not be changed.
+Set the values of "maven-username", "maven-password", "gpg-key-pass" and " gpg-private-key" for your account. The parameters to `provenance-download-name`, `provenance-download-sha256`, `target-download-name`, and `target-download-sha256` should not be changed.
 
 Once you trigger this workflow, your artifacts and provenance files will be added to a staging repository in Maven Central. You need to close the staging repository and then release:
 

--- a/actions/maven/publish/action.yml
+++ b/actions/maven/publish/action.yml
@@ -90,10 +90,7 @@ runs:
         GPG_KEY_PASS: "${{ inputs.gpg-key-pass }}"
         SLSA_DIR: "${{ inputs.provenance-download-name }}"
         PROVENANCE_FILES: "${{ inputs.provenance-download-name }}"
-        TARGET_DIR: "${{ inputs.target-download-name }}"
       run: |
-        # Change name of downloaded target directory
-        mv "${TARGET_DIR}" ./target
         cd __BUILDER_CHECKOUT_DIR__/actions/maven/publish/slsa-hashing-plugin && mvn clean install && cd -
         mvn javadoc:jar source:jar
         # Retrieve project version

--- a/actions/maven/publish/action.yml
+++ b/actions/maven/publish/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "The sha256 of the package provenance artifact."
     required: true
     type: string
+  target-download-name:
+    description: "The name of the target directory."
+    required: true
+    type: string
   target-download-sha256:
     description: "The sha256 of the target directory."
     required: true
@@ -67,7 +71,7 @@ runs:
     - name: Download the target dir
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@main
       with:
-        name: target
+        name: "${{ inputs.target-download-name }}"
         path: ./
         sha256: "${{ inputs.target-download-sha256 }}"
 
@@ -86,7 +90,10 @@ runs:
         GPG_KEY_PASS: "${{ inputs.gpg-key-pass }}"
         SLSA_DIR: "${{ inputs.provenance-download-name }}"
         PROVENANCE_FILES: "${{ inputs.provenance-download-name }}"
+        TARGET_DIR: "${{ inputs.target-download-name }}"
       run: |
+        # Change name of downloaded target directory
+        mv "${TARGET_DIR}" ./target
         cd __BUILDER_CHECKOUT_DIR__/actions/maven/publish/slsa-hashing-plugin && mvn clean install && cd -
         mvn javadoc:jar source:jar
         # Retrieve project version

--- a/internal/builders/gradle/action.yml
+++ b/internal/builders/gradle/action.yml
@@ -47,6 +47,10 @@ outputs:
       Users should verify the download against this digest to prevent tampering.
     value: ${{ steps.upload-build-dir.outputs.sha256 }}
 
+  package-download-name:
+    description: "Name of the artifact to download the build directory."
+    value: "${{ steps.rng.outputs.random }}-build"
+
 on:
   workflow_call:
 runs:
@@ -93,6 +97,12 @@ runs:
         cd "${project_root}" \
           && ./gradlew build -x test
 
+    # rng generates a random number to avoid name collision in artifacts
+    # when multiple workflows run concurrently.
+    - name: Generate random 16-byte value (32-char hex encoded)
+      id: rng
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@main
+
     - name: Put release artifacts in one directory
       shell: bash
       env:
@@ -119,5 +129,5 @@ runs:
       id: upload-build-dir
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@main
       with:
-        name: build
+        name: "${{ steps.rng.outputs.random }}-build"
         path: build

--- a/internal/builders/gradle/action.yml
+++ b/internal/builders/gradle/action.yml
@@ -40,14 +40,14 @@ inputs:
   slsa-workflow-secret14: {}
   slsa-workflow-secret15: {}
 outputs:
-  target-download-sha256:
+  build-download-sha256:
     description: >
       The sha256 digest of the "build" directory.
 
       Users should verify the download against this digest to prevent tampering.
     value: ${{ steps.upload-build-dir.outputs.sha256 }}
 
-  package-download-name:
+  build-download-name:
     description: "Name of the artifact to download the build directory."
     value: "${{ steps.rng.outputs.random }}-build"
 

--- a/internal/builders/maven/action.yml
+++ b/internal/builders/maven/action.yml
@@ -47,6 +47,10 @@ outputs:
       Users should verify the download against this digest to prevent tampering.
     value: ${{ steps.upload-target.outputs.sha256 }}
 
+  package-download-name:
+    description: "Name of the artifact to download the target directory."
+    value: "${{ steps.rng.outputs.random }}-target"
+
 on:
   workflow_call:
 runs:
@@ -103,9 +107,16 @@ runs:
         # not be in GITHUB_WORKSPACE, so we need to move the file.
         mv $(dirname "${SLSA_OUTPUTS_ARTIFACTS_FILE}") "${GITHUB_WORKSPACE}/../"
         mv target "${GITHUB_WORKSPACE}/"
+
+    # rng generates a random number to avoid name collision in artifacts
+    # when multiple workflows run concurrently.
+    - name: Generate random 16-byte value (32-char hex encoded)
+      id: rng
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@main
+
     - name: Upload target
       id: upload-target
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@main
       with:
-        name: target
+        name: "${{ steps.rng.outputs.random }}-target"
         path: target

--- a/internal/builders/maven/action.yml
+++ b/internal/builders/maven/action.yml
@@ -47,7 +47,7 @@ outputs:
       Users should verify the download against this digest to prevent tampering.
     value: ${{ steps.upload-target.outputs.sha256 }}
 
-  package-download-name:
+  target-download-name:
     description: "Name of the artifact to download the target directory."
     value: "${{ steps.rng.outputs.random }}-target"
 


### PR DESCRIPTION
Fixes the following from https://github.com/slsa-framework/slsa-github-generator/issues/2662:

- The internal Action. It must add randomization and return a new output
- The publish / download Actions. They need an additional input for the randomized name.