### PR TITLE
feat: enhance the ko workflow

### DIFF
--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -347,11 +347,11 @@ This section explains how to generate non-forgeable SLSA provenance with existin
          echo "${KO_PASSWORD}" | ko login ghcr.io --username "$KO_USER" --password-stdin
 
          # Build & push the image. Save the image name.
-         image_and_digest=$(ko build --tags="${tag}" .)
+         ko build --bare --tags="${tag}" --image-refs .digest
 
          # Output the image name and digest so we can generate provenance.
-         image=$(echo "${image_and_digest}" | cut -d'@' -f1 | cut -d':' -f1)
-         digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
+         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
+         digest=$(cat .digest| cut -d'@' -f2)
          echo "image=$image" >> "$GITHUB_OUTPUT"
          echo "digest=$digest" >> "$GITHUB_OUTPUT"
    ```


### PR DESCRIPTION
To summarize the PR:
- added the `--bare` option since we are defining the whole image name in `KO_DOCKER_REPO`, if we didn't specify the `--bare` option, the result would be different than the specified in that variable.
- used the `--image-refs` flag