### PR TITLE
docs: Fixes broken link on the hall of fame section of the  readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Several builders have been built using the ["Build Your Own Builder" (BYOB) fram
 
 1. [nodejs builder](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/nodejs#readme), by [@ianlewis](https://github.com/ianlewis)
 2. [JReleaser builder](https://github.com/jreleaser/release-action/tree/java#slsa-builder), by [@aalmiray](https://github.com/aalmiray)
-3. [Maven builder](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/maven/README.md), by [@AdamKorcz](https:/github.com/AdamKorcz)
-4. [Gradle builder](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/gradle/README.md), by [@AdamKorcz](https:/github.com/AdamKorcz)
+3. [Maven builder](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/maven/README.md), by [@AdamKorcz](https://github.com/AdamKorcz)
+4. [Gradle builder](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/gradle/README.md), by [@AdamKorcz](https://github.com/AdamKorcz)
 5. **Coming soon!** [Bazel builder](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/bazel/README.md), by [@enteraga6](https://github.com/enteraga6)
 
 ## Generate provenance


### PR DESCRIPTION
On the readme, there is a broken link to Adam Korcz's GitHub address. There is a `/` missing on the URL.

This PR fixes it. 😄 