### PR TITLE
fix: generic generator on macos runners

### DIFF
--- a/actions/generator/generic/create-base64-subjects-from-file/action.yml
+++ b/actions/generator/generic/create-base64-subjects-from-file/action.yml
@@ -66,7 +66,7 @@ runs:
 
         object="{\"artifact_name\": \"${UNTRUSTED_ARTIFACT_NAME}\", \"sha256\": \"${SHA256}\", \"filename\": \"${UNTRUSTED_FILENAME}\"}"
 
-        if test "$(uname)" = "Darwin"
+        if test "$RUNNER_OS" = "macOS"
         then
             base64_object=$(echo "$object" | base64)
         else

--- a/actions/generator/generic/create-base64-subjects-from-file/action.yml
+++ b/actions/generator/generic/create-base64-subjects-from-file/action.yml
@@ -65,7 +65,12 @@ runs:
         set -euo pipefail
 
         object="{\"artifact_name\": \"${UNTRUSTED_ARTIFACT_NAME}\", \"sha256\": \"${SHA256}\", \"filename\": \"${UNTRUSTED_FILENAME}\"}"
-        echo "$object" | jq
-        base64_object=$(echo "$object" | base64 -w0)
 
+        if test "$(uname)" = "Darwin"
+        then
+            base64_object=$(echo "$object" | base64)
+        else
+            base64_object=$(echo "$object" | base64 -w0)
+        fi
+        echo "$object" | jq
         echo "base64=${base64_object}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes an issue with the `base64` call to generate subject data on macOS-based runners.

Fixes and closes slsa-framework/slsa-github-generator#3015.