### PR TITLE
fix: don't move folders if they are already the same.

### DIFF
--- a/internal/builders/gradle/action.yml
+++ b/internal/builders/gradle/action.yml
@@ -124,7 +124,8 @@ runs:
       env:
         PROJECT_ROOT: ${{ steps.run_gradle_builder.outputs.validated_project_root }}
       run: |
-        mv "${PROJECT_ROOT}"/build "${GITHUB_WORKSPACE}"/
+        # ensure that directories are not the same before moving them, preventing an error when running action from the root of the repository
+        [[ "${PROJECT_ROOT}"/build -ef "${GITHUB_WORKSPACE}"/ ]] || mv "${PROJECT_ROOT}"/build "${GITHUB_WORKSPACE}"/
     - name: Upload build dir
       id: upload-build-dir
       uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@main

--- a/internal/builders/maven/action.yml
+++ b/internal/builders/maven/action.yml
@@ -105,7 +105,8 @@ runs:
           && mvn package  -Drun.hash.jarfile=true
         # NOTE: SLSA_OUTPUTS_ARTIFACTS_FILE is a relative path and the project_root may
         # not be in GITHUB_WORKSPACE, so we need to move the file.
-        mv $(dirname "${SLSA_OUTPUTS_ARTIFACTS_FILE}") "${GITHUB_WORKSPACE}/../"
+        # the following checks if the directories are different before executing the command, fixing an error when SLSA is generated from the root of a repository
+        [[ $(dirname "${SLSA_OUTPUTS_ARTIFACTS_FILE}") -ef "${GITHUB_WORKSPACE}/../" ]] || mv $(dirname "${SLSA_OUTPUTS_ARTIFACTS_FILE}") "${GITHUB_WORKSPACE}/../" 
         mv target "${GITHUB_WORKSPACE}/"
 
     # rng generates a random number to avoid name collision in artifacts


### PR DESCRIPTION
This PR resolves an error when running the Gradle or Maven actions on the root of the repository.
Resolves #2726
