### PR TITLE
chore: Update slsa-verifier version

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -91,7 +91,7 @@ runs:
         # release binaries when the compile-builder input is false.
         VERIFIER_REPOSITORY: slsa-framework/slsa-verifier # The repository to download the pre-built verifier binary from.
         VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64 # The name of the verifier binary in the release assets.
-        VERIFIER_RELEASE_BINARY_SHA256: eb7007070baa04976cb9e25a0d8034f8db030a86 # The expected hash of the verifier binary.
+        VERIFIER_RELEASE_BINARY_SHA256: 54e4f40bf120bce1cef1ff123fef3456e8c526f315c47e22ed6acfe02a06b9a8 # The expected hash of the verifier binary.
         VERIFIER_RELEASE: v2.5.1 # The version of the verifier to download.
 
         COMPILE_BUILDER: "${{ inputs.compile-builder }}"

--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -91,8 +91,8 @@ runs:
         # release binaries when the compile-builder input is false.
         VERIFIER_REPOSITORY: slsa-framework/slsa-verifier # The repository to download the pre-built verifier binary from.
         VERIFIER_RELEASE_BINARY: slsa-verifier-linux-amd64 # The name of the verifier binary in the release assets.
-        VERIFIER_RELEASE_BINARY_SHA256: e81900c9f11a44276e1552afb7c1f6ea7b13ad9c6efdb920d97f23a76659e25f # The expected hash of the verifier binary.
-        VERIFIER_RELEASE: v2.4.1 # The version of the verifier to download.
+        VERIFIER_RELEASE_BINARY_SHA256: eb7007070baa04976cb9e25a0d8034f8db030a86 # The expected hash of the verifier binary.
+        VERIFIER_RELEASE: v2.5.1 # The version of the verifier to download.
 
         COMPILE_BUILDER: "${{ inputs.compile-builder }}"
         # NOTE: If a builder reference is specified, then we will download this version of the builder.


### PR DESCRIPTION
# Summary

Update slsa-verifier version

## Testing Process

To LGTM this PR, verify that the sha256 is the same as in the official release page https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md

## Checklist

- [ ] Review the contributing [guidelines](./../CONTRIBUTING.md)
- [ ] Add a reference to related issues in the PR description.
- [ ] Update documentation if applicable.
- [ ] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](./../CHANGELOG.md) if applicable.
