### PR TITLE
ci: fix PR title checker

### DIFF
--- a/.github/workflows/pre-submit.pr-title.yml
+++ b/.github/workflows/pre-submit.pr-title.yml
@@ -26,7 +26,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@e914bff8ab5e6f1a6a270da6954cd6bfd1d7f1fb # v1
+      - uses: thehanimo/pr-title-checker@1d8cd483a2b73118406a187f54dca8a9415f1375 # v1.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
# Summary

Updates `thehanimo/pr-title-checker` to v1.4.2 and fixes the version comment. This should allow renovate to create PRs to update dependencies again since it's been broken since early Dec 2023.

Fixes #3022

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [x] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
