### PR TITLE
feat: workflow to update actions dist

### DIFF
--- a/.github/workflows/pre-submit.lint.yml
+++ b/.github/workflows/pre-submit.lint.yml
@@ -79,8 +79,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: shellcheck
         env:
-          SHELLCHECK_VERSION: "0.8.0"
-          SHELLCHECK_CHECKSUM: "ab6ee1b178f014d1b86d1e24da20d1139656c8b0ed34d2867fbb834dad02bf0a"
+          SHELLCHECK_VERSION: "0.10.0"
+          SHELLCHECK_CHECKSUM: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/pre-submit.lint.yml
+++ b/.github/workflows/pre-submit.lint.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: actionlint
         env:
-          ACTIONLINT_VERSION: "1.6.24"
-          ACTIONLINT_CHECKSUM: "3c5818744143a5d6754edd3dcc4c2b32c9dfcdd3bb30e0e108fb5e5c505262d4"
+          ACTIONLINT_VERSION: "1.7.0"
+          ACTIONLINT_CHECKSUM: "8aae9148f61952d11a97651852fdc7dffd2b762ed3cdd28b3c2232ae5f55d4db"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -1,0 +1,96 @@
+# A workflow to run against renovate-bot's PRs,
+# such as `make package` after it updates the package.json and package-lock.json files.
+
+# The potentially untrusted code is first run inside a low-privilege Job, and the diff is uploaded as an artifact.
+# Then a higher-privilege Job applies the diff and pushes the changes to the PR.
+# It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!
+
+# There have been vulnerabilities with using `git apply` https://github.blog/2023-04-25-git-security-vulnerabilities-announced-4/
+# At this point a compromised git binary cannot modify any of this repo's branches, only the PR fork's branch,
+# due to our branch protection rules and CODEOWNERS.
+# It aslso cannot submit a new release or modify exsiting releases due to tag protection rules.
+
+name: Update actions dist post-commit
+
+permissions: {}
+
+on:
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: "The pull request number."
+                required: true
+                type: number
+
+jobs:
+    diff:
+        permissions:
+            # This Job executes the PR's untrusted code, so it must how low permissions.
+            pull-requests: read
+        outputs:
+            patch_not_empty: ${{ steps.diff.outputs.patch_not_empty }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+              with:
+                  repository: ${{ github.repository }}
+                  persist-credentials: false
+            - name: checkout-pr
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh pr checkout ${{ inputs.pr_number }}
+            - name: run-command
+              run: |
+                (
+                    cd ./actions/installer/dist/../ && \
+                    make clean && \
+                    make package
+                )
+            - name: diff
+              id: diff
+              run: |
+                  git add .
+                  git status
+                  git diff HEAD > changes.patch
+                  [ -z "$(cat changes.patch)" ] && RESULT=false || RESULT=true
+                  echo "patch_not_empty=$RESULT" >> "$GITHUB_OUTPUT"
+            - name: upload
+              uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+              with:
+                  name: changes.patch
+                  path: changes.patch
+
+    push:
+        if: needs.diff.outputs.patch_not_empty == 'true'
+        needs: diff
+        runs-on: ubuntu-latest
+        permissions:
+            # This Job does not run untrusted code, but it does need to push changes to the PR's branch.
+            pull-requests: read
+            contents: write
+        steps:
+            - name: checkout
+              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            - name: checkout-pr
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh pr checkout ${{ inputs.pr_number }}
+            - name: download-patch
+              uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+              with:
+                  name: changes.patch
+            - id: apply
+              run: |
+                  git apply changes.patch
+                  rm changes.patch
+            # example from
+            # https://github.com/actions/checkout/blob/cd7d8d697e10461458bc61a30d094dc601a8b017/README.md#push-a-commit-using-the-built-in-token
+            - name: push
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git add .
+                  git status
+                  git commit -m "update actions dist"
+                  git push

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -98,5 +98,5 @@ jobs:
                   git config user.email github-actions@github.com
                   git add .
                   git status
-                  git commit -m "update actions dist"
+                  git commit -s -m "update actions dist"
                   git push

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -39,14 +39,19 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh pr checkout ${{ inputs.pr_number }}
+                  PR_NUMBER: ${{ inputs.pr_number }}
+              run: gh pr checkout "$PR_NUMBER"
             - name: run-command
               run: |
-                (
-                    cd ./actions/installer/dist/../ && \
-                    make clean && \
-                    make package
-                )
+                find ./ -name "dist" -not -path "*/node_modules/*" \
+                  | xargs dirname \
+                  | xargs -I {} sh -c '(
+                    echo "Updating {}" && \
+                    cd {} && \
+                    make clean \
+                    && make package
+                  )'
+
             - name: diff
               id: diff
               run: |
@@ -75,7 +80,8 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh pr checkout ${{ inputs.pr_number }}
+                  PR_NUMBER: ${{ inputs.pr_number }}
+              run: gh pr checkout "$PR_NUMBER"
             - name: download-patch
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -1,3 +1,18 @@
+# Copyright 2023 SLSA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # A workflow to run against renovate-bot's PRs,
 # such as `make package` after it updates the package.json and package-lock.json files.
 

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -58,8 +58,8 @@ jobs:
               run: gh pr checkout "$PR_NUMBER"
             - name: run-command
               run: |
-                find ./ -name "dist" -not -path "*/node_modules/*" \
-                  | xargs dirname \
+                find ./ -name "dist" -not -path "*/node_modules/*" -print0 \
+                  | xargs -0 dirname \
                   | xargs -I {} sh -c '(
                     echo "Updating {}" && \
                     cd {} && \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,26 @@ git merge --signoff main
 Before you submit your change run the unit tests and linters to ensure your
 changes are ready to go. See the [Testing](#testing) section for more info.
 
+#### Updating Github Actions Dependencies
+
+##### Renovate-Bot PRs
+
+`renovate-bot` will periodically send PRs to update the `package.json` and `package-lock.json` in the Github Actions of this repo.
+But, it will not also automatically recompile the packages into `.js` files.
+
+We use a Workflow [Update actions dist post-commit](../.github/workflows/update-actions-dist-post-commit.yml) to
+help maintainers easily recompile the Github Actions against a PR.
+
+Use the UI to invoke the workflow
+
+[update-actions-dist-post-commit.yml](https://github.com/slsa-framework/slsa-verifier/actions/workflows/update-actions-dist-post-commit.yml)
+
+or invoke with
+
+```shell
+gh workflow run update-actions-dist-post-commit.yml -F pr_number=<pull request number>
+```
+
 #### Submit a PR
 
 Once your change is ready you can submit a PR via the website.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ welcome!
     - [Development Basics](#development-basics)
     - [Make your changes](#make-your-changes)
     - [Run tests](#run-tests)
+    - [Updating Github Actions Dependencies](#updating-github-actions-dependencies)
+      - [Renovate-Bot PRs](#renovate-bot-prs)
     - [Submit a PR](#submit-a-pr)
   - [Preferred Languages](#preferred-languages)
 - [Testing](#testing)


### PR DESCRIPTION
# Summary

Similar to slsa-verifier's https://github.com/slsa-framework/slsa-verifier/pull/760

This PR adds a manually-invoked workflow to run against renovate-bot's PRs to update the node `dist` folders.

I made one small change to use the `${{ inputs.pr_number }} ` as an environment variable, to harden against [script injection](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks). See also https://github.com/slsa-framework/slsa-verifier/pull/771

Also updating shellckeck to fix this lint error:
 - https://github.com/slsa-framework/slsa-github-generator/actions/runs/9101693389/job/25019502486#step:4:21

```
Error: input type of workflow_dispatch event must be one of "string", "boolean", "choice", "environment" but got "number"
```

## Testing Process

I ran this against my fork's version of PR #3649. It did update the dist folders and the check-dists checks pass
 - https://github.com/ramonpetgrave64/slsa-github-generator/actions/runs/9101190828/job/25017786420?pr=9
   -  https://github.com/slsa-framework/slsa-verifier/pull/760/files#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [ ] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [ ] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
