### PR TITLE
chore: allow Renovate to create new config warning issues

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "vulnerabilityAlerts": {
     "schedule": "* 0-4 * * *"
   },
+  "configWarningReuseIssue": false,
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {


### PR DESCRIPTION
# Summary

- Set `configWarningReuseIssue` to `false`.

Old behavior: Renovate re-opens a old config warning issue.

New behavior: Renovate creates a new config warning issue.

Read the [Renovate docs, `configWarningReuseIssue` config option](https://docs.renovatebot.com/configuration-options/#configwarningreuseissue) to learn more.

## More context

@ianlewis mentioned they want Renovate to create a _new issue_ instead of _re-opening_ an old one:

- https://github.com/slsa-framework/slsa-github-generator/pull/3635#issuecomment-2116420633

Here's an example of a Renovate config warning issue that was re-opened by Renovate recently:

- https://github.com/slsa-framework/slsa-github-generator/issues/404

## Testing Process

- Manually reviewed configuration change

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [ ] Update documentation if applicable.
- [ ] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
