### PR TITLE
ci: Add DCO pre-submit

### DIFF
--- a/.github/workflows/pre-submit.dco.yml
+++ b/.github/workflows/pre-submit.dco.yml
@@ -1,0 +1,29 @@
+# Copyright 2023 SLSA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: pre-submit DCO
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: KineticCafe/actions-dco@50a0f2afff9433641a18fa909c60eb3805db583e # v1.3.0

--- a/.github/workflows/pre-submit.dco.yml
+++ b/.github/workflows/pre-submit.dco.yml
@@ -23,7 +23,7 @@ on:
 permissions: read-all
 
 jobs:
-  check:
+  dco-check:
     runs-on: ubuntu-latest
     steps:
       - uses: KineticCafe/actions-dco@50a0f2afff9433641a18fa909c60eb3805db583e # v1.3.0


### PR DESCRIPTION
# Summary

Add a pre-submit for https://github.com/KineticCafe/actions-dco. This will replace the DCO app which we use currently.

Fixes #3685

## Testing Process

N/A

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [x] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
