### PR TITLE
fix: maven e2e: remove verify job

### DIFF
--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -33,26 +33,3 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@main
     with:
       directory: ./e2e/maven/workflow_dispatch
-
-  verify:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: slsa-framework/slsa-github-generator/actions/maven/secure-download-attestations@main
-        with:
-          name: "${{ needs.build.outputs.provenance-download-name }}"
-          sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"
-          path: ./
-      - uses: slsa-framework/slsa-github-generator/actions/maven/secure-download-target@main
-        with:
-          name: "${{ needs.build.outputs.target-download-name }}"
-          sha256: "${{ needs.build.outputs.target-download-sha256 }}"
-          path: ./
-      - uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
-      - name: Verify artifact
-        env:
-          PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}/test-java-project-1.21.97.jar.build.slsa
-          TARGET_PATH: ./target/test-java-project-1.21.97.jar
-          SOURCE_URI: github.com/slsa-framework/slsa-github-generator
-          SLSA_VERIFIER_TESTING: "true"
-        run: slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri $SOURCE_URI

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -38,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: slsa-framework/slsa-github-generator/actions/maven/secure-download-attestations@main
         with:
           name: "${{ needs.build.outputs.provenance-download-name }}"
@@ -55,5 +54,6 @@ jobs:
           PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}
           TARGET_PATH: ${{ needs.build.outputs.target-download-name }}
         run: |
+          pwd
           ls -lah -R ./
           slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri github.com/slsa-framework/slsa-github-generator

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -54,4 +54,6 @@ jobs:
         env:
           PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}
           TARGET_PATH: ${{ needs.build.outputs.target-download-name }}
-        run: slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri github.com/slsa-framework/slsa-github-generator
+        run: |
+          ls -lah -R ./
+          slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri github.com/slsa-framework/slsa-github-generator

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -52,9 +52,7 @@ jobs:
       - name: Verify artifact
         env:
           PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}/test-java-project-1.21.97.jar.build.slsa
-          TARGET_PATH: ./target//test-java-project-1.21.97.jar
+          TARGET_PATH: ./target/test-java-project-1.21.97.jar
           SOURCE_URI: github.com/slsa-framework/slsa-github-generator
-        run: |
-          pwd
-          ls -lah -R ./
-          slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri $SOURCE_URI
+          SLSA_VERIFIER_TESTING: "true"
+        run: slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri $SOURCE_URI

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -51,9 +51,10 @@ jobs:
       - uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
       - name: Verify artifact
         env:
-          PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}
-          TARGET_PATH: ${{ needs.build.outputs.target-download-name }}
+          PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}/test-java-project-1.21.97.jar.build.slsa
+          TARGET_PATH: ./target//test-java-project-1.21.97.jar
+          SOURCE_URI: github.com/slsa-framework/slsa-github-generator
         run: |
           pwd
           ls -lah -R ./
-          slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri github.com/slsa-framework/slsa-github-generator
+          slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri $SOURCE_URI

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           PROVENANCE_PATH: ${{ needs.build.outputs.provenance-download-name }}
           TARGET_PATH: ${{ needs.build.outputs.target-download-name }}
-        run: slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH"
+        run: slsa-verifier verify-artifact "$TARGET_PATH" --provenance-path "$PROVENANCE_PATH" --source-uri github.com/slsa-framework/slsa-github-generator


### PR DESCRIPTION
# Summary

Followup to #3746 

Removes the verify job, which won't work, because the ref will be incorrect.

This workflow will only be checking if the builds succeed, and do publish provenance.

 - https://github.com/slsa-framework/slsa-github-generator/actions/runs/10115454784/job/27976327657#step:5:1

```
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verifying artifact ./target/test-java-project-1.21.97.jar: FAILED: invalid ref: "refs/heads/main": unexpected ref type: "heads"

FAILED: SLSA verification failed: invalid ref: "refs/heads/main": unexpected ref type: "heads"
Error: Process completed with exit code 1.
```

## Testing Process

The e2e test is executed in this PR, which now passes.

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [ ] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
