### PR TITLE
Add ability to attest the supplied multi-arch image

### DIFF
--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -87,6 +87,11 @@ on:
         description: "If set, provenance is pushed to this registry instead of image registry."
         required: false
         type: string
+      recursive:
+        description: "If set, for the specified multi-arch image, additionally sign each discrete image."
+        required: false
+        type: boolean
+        default: false
     outputs:
       # Note: we use this output because there is no buildt-in `outcome` and `result` is always `success`
       # if `continue-on-error` is set to `true`.
@@ -268,6 +273,7 @@ jobs:
           GITHUB_CONTEXT: "${{ toJSON(github) }}"
           VARS_CONTEXT: "${{ toJSON(vars) }}"
           UNTRUSTED_PROVENANCE_REPOSITORY: "${{ inputs.provenance-repository }}"
+          RECURSIVE: "${{ inputs.recursive }}"
         run: |
           set -euo pipefail
 
@@ -283,6 +289,7 @@ jobs:
           cosign attest --predicate="$predicate_name" \
             --type slsaprovenance \
             --yes \
+            --recursive="${RECURSIVE}" \
             "${UNTRUSTED_IMAGE}@${UNTRUSTED_DIGEST}"
 
       - name: Final outcome


### PR DESCRIPTION
# Summary

When using docker buildx to build multi-arch images, SLSA workflow may need to recursively attest underlying images for the multi-arch build.

This is possible using `--recursive=true` according to the `cosign attest` help:
```
    -r, --recursive=false:
        if a multi-arch image is specified, additionally sign each discrete image
```

This change allows to provide `recursive` input flag in the workflow.
...

## Testing Process

...

## Checklist

- [ ] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [ ] Add a reference to related issues in the PR description.
- [ ] Update documentation if applicable.
- [ ] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
