### PR TITLE
chore: go1.23.1 golangci lint 1.6.1

### DIFF
--- a/.github/workflows/pre-submit.lint.yml
+++ b/.github/workflows/pre-submit.lint.yml
@@ -87,8 +87,8 @@ jobs:
         with:
           go-version-file: "go.mod"
       - env:
-          GOLANGCI_LINT_VERSION: "1.57.0"
-          GOLANGCI_LINT_CHECKSUM: "fc7a9f73d2e3de6aa0ef8d8586906e0067fed577f704b3b0bc29cdd6ad0b74d8"
+          GOLANGCI_LINT_VERSION: "1.61.0"
+          GOLANGCI_LINT_CHECKSUM: "77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111"
         run: |
           set -euo pipefail
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable errorlint
     # - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     # TODO(github.com/slsa-framework/slsa-github-generator/issues/450): enable gci
     # - gci
     - gochecknoinits

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slsa-framework/slsa-github-generator
 
-go 1.21
+go 1.23.1
 
 require (
 	github.com/coreos/go-oidc/v3 v3.10.0

--- a/internal/builders/docker/pkg/builder_test.go
+++ b/internal/builders/docker/pkg/builder_test.go
@@ -53,7 +53,7 @@ func Test_CreateBuildDefinition(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 
@@ -206,7 +206,7 @@ func Test_inspectArtifacts(t *testing.T) {
 	want := []intoto.Subject{s1, s2, s3, s4}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 
@@ -256,7 +256,7 @@ func Test_inspectArtifactsNoRoot(t *testing.T) {
 	want := []intoto.Subject{s1, s2, s3, s4}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 
@@ -317,7 +317,7 @@ func Test_ParseProvenance(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 
@@ -345,7 +345,7 @@ func Test_ProvenanceStatementSLSA1_ToDockerBuildConfig(t *testing.T) {
 		ForceCheckout:   true,
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 

--- a/internal/builders/docker/pkg/common_test.go
+++ b/internal/builders/docker/pkg/common_test.go
@@ -62,7 +62,7 @@ func Test_BuildDefinition(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 

--- a/internal/builders/docker/pkg/config_test.go
+++ b/internal/builders/docker/pkg/config_test.go
@@ -52,7 +52,7 @@ func Test_LoadBuildConfigFromFile(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }
 
@@ -85,6 +85,6 @@ func Test_NewDockerBuildConfig(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(diff)
+		t.Error(diff)
 	}
 }

--- a/internal/builders/go/e2e-presubmits/go.mod
+++ b/internal/builders/go/e2e-presubmits/go.mod
@@ -1,6 +1,6 @@
 module slsa-framework/example-package
 
-go 1.21
+go 1.23.1
 
 require github.com/pborman/uuid v1.2.1
 

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -46,7 +46,7 @@ func checkWorkingDir(t *testing.T, wd, expected string) {
 	}
 
 	if expectedWd != wd {
-		t.Errorf(cmp.Diff(wd, expectedWd))
+		t.Error(cmp.Diff(wd, expectedWd))
 	}
 }
 
@@ -335,19 +335,19 @@ func Test_runBuild(t *testing.T) {
 			}
 
 			if !cmp.Equal(subject, tt.subject) {
-				t.Errorf(cmp.Diff(subject, tt.subject))
+				t.Error(cmp.Diff(subject, tt.subject))
 			}
 
 			commands := append([]string{goc, "build", "-mod=vendor"}, tt.commands...)
 			if !cmp.Equal(cmd, commands) {
-				t.Errorf(cmp.Diff(cmd, commands))
+				t.Error(cmp.Diff(cmd, commands))
 			}
 
 			checkWorkingDir(t, wd, tt.workingDir)
 
 			sorted := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 			if !cmp.Equal(env, tt.envs, sorted) {
-				t.Errorf(cmp.Diff(env, tt.envs))
+				t.Error(cmp.Diff(env, tt.envs))
 			}
 		})
 	}

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -298,7 +298,6 @@ func Test_runBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			// *** WARNING: do not enable t.Parallel(), because we're writing to environment variables ***.
 			file, err := os.CreateTemp("", "")

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -90,7 +90,6 @@ func Test_isAllowedEnvVariable(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -126,7 +125,6 @@ func Test_getOutputBinaryPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -177,7 +175,6 @@ func Test_isAllowedArg(t *testing.T) {
 		})
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -442,7 +439,6 @@ func Test_generateOutputFilename(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			// Note: disable parallelism to avoid env variable clobbering between tests.
 			// t.Parallel()
@@ -595,7 +591,6 @@ func Test_SetArgEnvVariables(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -704,7 +699,6 @@ func Test_generateEnvVariables(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -862,7 +856,6 @@ func Test_generateLdflags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			// Disable to avoid env clobbering between tests.
 			// t.Parallel()
@@ -954,7 +947,6 @@ func Test_generateFlags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1024,7 +1016,6 @@ func Test_generateCommand(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/builders/go/pkg/build_test.go
+++ b/internal/builders/go/pkg/build_test.go
@@ -95,7 +95,7 @@ func Test_isAllowedEnvVariable(t *testing.T) {
 
 			r := isAllowedEnvVariable(tt.variable)
 			if !cmp.Equal(r, tt.expected) {
-				t.Errorf(cmp.Diff(r, tt.expected))
+				t.Error(cmp.Diff(r, tt.expected))
 			}
 		})
 	}
@@ -138,7 +138,7 @@ func Test_getOutputBinaryPath(t *testing.T) {
 			}
 
 			if !cmp.Equal(r, tt.path) {
-				t.Errorf(cmp.Diff(r, tt.path))
+				t.Error(cmp.Diff(r, tt.path))
 			}
 		})
 	}
@@ -180,7 +180,7 @@ func Test_isAllowedArg(t *testing.T) {
 
 			r := isAllowedArg(tt.argument)
 			if !cmp.Equal(r, tt.expected) {
-				t.Errorf(cmp.Diff(r, tt.expected))
+				t.Error(cmp.Diff(r, tt.expected))
 			}
 		})
 	}
@@ -487,7 +487,7 @@ func Test_generateOutputFilename(t *testing.T) {
 			}
 
 			if fn != tt.expected.fn {
-				t.Errorf(cmp.Diff(fn, tt.expected.fn))
+				t.Error(cmp.Diff(fn, tt.expected.fn))
 			}
 		})
 	}
@@ -614,7 +614,7 @@ func Test_SetArgEnvVariables(t *testing.T) {
 
 			sorted := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 			if !cmp.Equal(b.argEnv, tt.expected.env, sorted) {
-				t.Errorf(cmp.Diff(b.argEnv, tt.expected.env))
+				t.Error(cmp.Diff(b.argEnv, tt.expected.env))
 			}
 		})
 	}
@@ -725,7 +725,7 @@ func Test_generateEnvVariables(t *testing.T) {
 			expectedFlags := tt.expected.flags
 			sorted := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 			if !cmp.Equal(flags, expectedFlags, sorted) {
-				t.Errorf(cmp.Diff(flags, expectedFlags))
+				t.Error(cmp.Diff(flags, expectedFlags))
 			}
 		})
 	}
@@ -898,7 +898,7 @@ func Test_generateLdflags(t *testing.T) {
 			}
 			// Note: generated env variables contain the process's env variables too.
 			if !cmp.Equal(ldflags, tt.outldflags) {
-				t.Errorf(cmp.Diff(ldflags, tt.outldflags))
+				t.Error(cmp.Diff(ldflags, tt.outldflags))
 			}
 		})
 	}
@@ -972,7 +972,7 @@ func Test_generateFlags(t *testing.T) {
 			// Note: generated env variables contain the process's env variables too.
 			sorted := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 			if !cmp.Equal(flags, expectedFlags, sorted) {
-				t.Errorf(cmp.Diff(flags, expectedFlags))
+				t.Error(cmp.Diff(flags, expectedFlags))
 			}
 		})
 	}
@@ -1047,7 +1047,7 @@ func Test_generateCommand(t *testing.T) {
 
 				sorted := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 				if !cmp.Equal(command, expectedCommand, sorted) {
-					t.Errorf(cmp.Diff(command, expectedCommand))
+					t.Error(cmp.Diff(command, expectedCommand))
 				}
 			}
 		})

--- a/internal/builders/go/pkg/config_test.go
+++ b/internal/builders/go/pkg/config_test.go
@@ -185,7 +185,6 @@ func Test_ConfigFromFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/builders/go/pkg/config_test.go
+++ b/internal/builders/go/pkg/config_test.go
@@ -198,7 +198,7 @@ func Test_ConfigFromFile(t *testing.T) {
 			}
 
 			if !cmp.Equal(*cfg, tt.config) {
-				t.Errorf(cmp.Diff(*cfg, tt.config))
+				t.Error(cmp.Diff(*cfg, tt.config))
 			}
 		})
 	}

--- a/internal/builders/go/pkg/testdata/go/go.mod
+++ b/internal/builders/go/pkg/testdata/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/slsa-framework/slsa-github-generator/internal/builders/go/pkg/testdata/go
 
-go 1.19
+go 1.23.1

--- a/internal/utils/marshal_test.go
+++ b/internal/utils/marshal_test.go
@@ -46,7 +46,6 @@ func Test_MarshalToString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -91,7 +90,6 @@ func Test_UnmarshalList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/utils/marshal_test.go
+++ b/internal/utils/marshal_test.go
@@ -54,7 +54,7 @@ func Test_MarshalToString(t *testing.T) {
 				t.Errorf("MarshalToString: %v", err)
 			}
 			if !cmp.Equal(r, tt.expected) {
-				t.Errorf(cmp.Diff(r, tt.expected))
+				t.Error(cmp.Diff(r, tt.expected))
 			}
 		})
 	}
@@ -99,7 +99,7 @@ func Test_UnmarshalList(t *testing.T) {
 			}
 
 			if !cmp.Equal(r, tt.expected) {
-				t.Errorf(cmp.Diff(r, tt.expected))
+				t.Error(cmp.Diff(r, tt.expected))
 			}
 		})
 	}

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -69,7 +69,6 @@ func Test_PathIsUnderCurrentDirectory(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -121,7 +120,6 @@ func Test_VerifyAttestationPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,7 +191,6 @@ func Test_CreateNewFileUnderCurrentDirectory(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			cleanup, err := tempWD()
 			if err != nil {
@@ -273,7 +270,6 @@ func Test_PathIsUnderDirectory(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/signing/sigstore/rekor.go
+++ b/signing/sigstore/rekor.go
@@ -99,8 +99,6 @@ func (r *Rekor) Upload(ctx context.Context, att signing.Attestation) (signing.Lo
 
 	var uuid string
 	for ix, entry := range resp.Payload {
-		entry := entry
-
 		if err := cosign.VerifyTLogEntryOffline(ctx, &entry, pubs); err != nil {
 			return nil, fmt.Errorf("validating log entry: %w", err)
 		}


### PR DESCRIPTION
# Summary

Followup to https://github.com/slsa-framework/slsa-verifier/pull/810

- upgrades to go 1.23.1 and golangci-lint 1.6.1
- makes necessary changes for the linter
  - as of go 1.22, no need to make a copy of the loop variable
  - change non-string use of `fmt.Errorf(err)` to `fmt.Error(err)`

## Testing Process

unit tests continue to pass, as well as the linter

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [x] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
