### PR TITLE
fix: revert softprops/action-gh-release to v2.1.0

### DIFF
--- a/.github/workflows/builder_container-based_slsa3.yml
+++ b/.github/workflows/builder_container-based_slsa3.yml
@@ -598,7 +598,7 @@ jobs:
           path: "${{ needs.provenance.outputs.provenance-name }}"
 
       - name: Upload provenance new tag
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: startsWith(github.ref, 'refs/tags/') && inputs.upload-tag-name == ''
         id: release-new-tags
         with:
@@ -609,7 +609,7 @@ jobs:
           draft: ${{ inputs.draft-release }}
 
       - name: Upload provenance tag name
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: inputs.upload-tag-name != ''
         with:
           prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -399,7 +399,7 @@ jobs:
           sha256: "${{ needs.provenance.outputs.go-provenance-sha256 }}"
 
       - name: Upload provenance
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           tag_name: ${{ inputs.upload-tag-name }}
           prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -285,7 +285,7 @@ jobs:
           sha256: "${{ needs.generator.outputs.provenance-sha256 }}"
 
       - name: Upload provenance
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         id: release
         with:
           draft: ${{ inputs.draft-release }}

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -200,7 +200,7 @@ jobs:
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - name: Release
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -203,7 +203,7 @@ jobs:
           name: artifact2
 
       - name: Upload assets
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           files: |
             artifact1


### PR DESCRIPTION
# Summary

fixes https://github.com/slsa-framework/slsa-github-generator/issues/4031#issuecomment-2549595578.

revert softprops/action-gh-release to v2.1.0

Folks suggest that 2.1.0 is the last known good version. https://github.com/softprops/action-gh-release/issues/556

## Testing Process

N/A

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [ ] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
