### PR TITLE
fix: update pre-submit to ubuntu24

### DIFF
--- a/.github/workflows/scripts/pre-submit.e2e.go.default.sh
+++ b/.github/workflows/scripts/pre-submit.e2e.go.default.sh
@@ -41,7 +41,7 @@ LDFLAGS=$(e2e_this_file | cut -d '.' -f4 | grep -v noldflags)
 e2e_verify_common_all "$ATTESTATION"
 
 # Verify Go specific environment vars are set
-e2e_verify_predicate_invocation_environment "$ATTESTATION" "os" "ubuntu22"
+e2e_verify_predicate_invocation_environment "$ATTESTATION" "os" "ubuntu24"
 e2e_verify_predicate_invocation_environment "$ATTESTATION" "arch" "X64"
 
 # Verify the subject and build type


### PR DESCRIPTION
# Summary

Update pre-submit to use ubuntu24

https://github.com/slsa-framework/slsa-github-generator/actions/runs/12999310515/job/36254511524?pr=4041

```
Run ./.github/workflows/scripts/pre-submit.e2e.go.default.sh
✖ ubuntu24 == ubuntu22 :: .predicate.invocation.environment.os should be ubuntu22
Error: Process completed with exit code 1.
```

## Testing Process

This PR's pre-submits should pass.

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [ ] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
