### PR TITLE
chore: update refs for release v2.1.0

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -62,7 +62,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout builder repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/secure-download-artifact/action.yml
+++ b/.github/actions/secure-download-artifact/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Compute the hash
       id: compute
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0
       with:
         path: "${{ steps.validate-path.outputs.file_path }}"
 

--- a/.github/actions/secure-download-folder/action.yml
+++ b/.github/actions/secure-download-folder/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Compute a random value
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
     - name: Download the artifact
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -41,7 +41,7 @@ runs:
 
     - name: Compute the hash
       id: compute
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0
       with:
         path: "${{ steps.rng.outputs.random }}/folder.tgz"
 

--- a/.github/actions/secure-upload-artifact/action.yml
+++ b/.github/actions/secure-upload-artifact/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Compute binary hash
       id: compute-digest
-      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/compute-sha256@v2.1.0
       with:
         path: "${{ inputs.path }}"
 

--- a/.github/actions/secure-upload-folder/action.yml
+++ b/.github/actions/secure-upload-folder/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Upload the artifact
       id: upload
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
       with:
         name: "${{ inputs.name }}"
         path: "${{ steps.create.outputs.tarball-path }}"

--- a/.github/workflows/builder_bazel_slsa3.yml
+++ b/.github/workflows/builder_bazel_slsa3.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
@@ -100,6 +100,6 @@ jobs:
       id-token: write # For signing.
       contents: read # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0
     with:
       slsa-token: ${{ needs.slsa-setup.outputs.slsa-token }}

--- a/.github/workflows/builder_container-based_slsa3.yml
+++ b/.github/workflows/builder_container-based_slsa3.yml
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
   # This detects the repository and ref of the reusable workflow.
   # For pull request, this gets the referenced slsa-github-generator workflow.
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0
 
   ###################################################################
   #                                                                 #
@@ -197,7 +197,7 @@ jobs:
     steps:
       - name: Generate builder binary
         id: generate
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -357,7 +357,7 @@ jobs:
           docker login "${untrusted_registry}" -u "${username}" -p "${password}"
 
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -485,7 +485,7 @@ jobs:
       provenance-sha256: ${{ steps.upload-signed.outputs.sha256 }}
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -575,7 +575,7 @@ jobs:
     if: inputs.upload-assets && (startsWith(github.ref, 'refs/tags/') || inputs.upload-tag-name != '')
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/builder_go_slsa3.yml
+++ b/.github/workflows/builder_go_slsa3.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
   detect-env:
     outputs:
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0
 
   ###################################################################
   #                                                                 #
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: Generate builder binary
         id: generate
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -191,7 +191,7 @@ jobs:
     needs: [builder, rng, detect-env]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -238,7 +238,7 @@ jobs:
     needs: [builder, build-dry, rng, detect-env]
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -320,7 +320,7 @@ jobs:
       go-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -378,7 +378,7 @@ jobs:
     if: inputs.upload-assets && (startsWith(github.ref, 'refs/tags/') || inputs.upload-tag-name != '')
     steps:
       - name: Checkout builder repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/builder_gradle_slsa3.yml
+++ b/.github/workflows/builder_gradle_slsa3.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
@@ -85,7 +85,7 @@ jobs:
       id-token: write # For signing.
       contents: read # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0
     with:
       slsa-token: ${{ needs.slsa-setup.outputs.slsa-token }}
 

--- a/.github/workflows/builder_maven_slsa3.yml
+++ b/.github/workflows/builder_maven_slsa3.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: "${{ inputs.rekor-log-public }}"
@@ -81,7 +81,7 @@ jobs:
       id-token: write # For signing.
       contents: read # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0
     with:
       slsa-token: "${{ needs.slsa-setup.outputs.slsa-token }}"
 

--- a/.github/workflows/builder_nodejs_slsa3.yml
+++ b/.github/workflows/builder_nodejs_slsa3.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Generate the token
         id: generate
-        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
@@ -104,6 +104,6 @@ jobs:
       id-token: write # For signing.
       contents: read # For repo checkout of private repos.
       actions: read # For getting workflow run on private repos.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_lowperms-generic_slsa3.yml@v2.1.0
     with:
       slsa-token: ${{ needs.slsa-setup.outputs.slsa-token }}

--- a/.github/workflows/delegator_generic_slsa3.yml
+++ b/.github/workflows/delegator_generic_slsa3.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
   # verify-token verifies the slsa token.
   verify-token:
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Verify token
         id: verify
-        uses: slsa-framework/slsa-github-generator/.github/actions/verify-token@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/verify-token@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_generic_slsa3.yml"
           slsa-unverified-token: ${{ inputs.slsa-token }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload predicate
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_PREDICATE_FILE }}"
           path: ${{ env.SLSA_PREDICATE_FILE }}
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check private repos
-        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@v2.1.0
         with:
           error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).builder.rekor_log_public }}
@@ -147,7 +147,7 @@ jobs:
           echo "$RUNNER: $RUNNER"
 
       - name: Checkout the tool repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: ${{ needs.verify-token.outputs.tool-repository }}
           ref: ${{ needs.verify-token.outputs.tool-ref }}
@@ -171,7 +171,7 @@ jobs:
           tree
 
       - name: Checkout the project repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0
         with:
           fetch-depth: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).source.checkout.fetch_depth }}
           checkout-sha1: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).source.checkout.sha1 }}
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload artifact layout file
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_ARTIFACTS_FILE }}"
           path: "${{ env.SLSA_ARTIFACTS_FILE }}"
@@ -229,14 +229,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the artifact layout file
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_ARTIFACTS_FILE }}"
           path: "${{ env.SLSA_ARTIFACTS_FILE }}"
           sha256: ${{ needs.build-artifacts-ubuntu.outputs.artifacts-layout-sha256 }}
 
       - name: Download the predicate file
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_PREDICATE_FILE }}"
           path: ${{ env.SLSA_PREDICATE_FILE }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Generate attestations
         id: attestations
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-attestations@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-attestations@v2.1.0
         with:
           slsa-layout-file: ${{ env.SLSA_ARTIFACTS_FILE }}
           predicate-type: ${{ steps.predicate-type.outputs.predicate-type }}
@@ -275,14 +275,14 @@ jobs:
 
       - name: Sign attestations
         id: sign
-        uses: slsa-framework/slsa-github-generator/.github/actions/sign-attestations@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/sign-attestations@v2.1.0
         with:
           attestations: attestations
           output-folder: "${{ needs.rng.outputs.value }}-slsa-attestations"
 
       - name: Upload attestations
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-slsa-attestations"
           path: "${{ needs.rng.outputs.value }}-slsa-attestations"

--- a/.github/workflows/delegator_lowperms-generic_slsa3.yml
+++ b/.github/workflows/delegator_lowperms-generic_slsa3.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Generate random 16-byte value (32-char hex encoded)
         id: rng
-        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
   # verify-token verifies the slsa token.
   verify-token:
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Verify token
         id: verify
-        uses: slsa-framework/slsa-github-generator/.github/actions/verify-token@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/verify-token@v2.1.0
         with:
           slsa-workflow-recipient: "delegator_lowperms-generic_slsa3.yml"
           slsa-unverified-token: ${{ inputs.slsa-token }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload predicate
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_PREDICATE_FILE }}"
           path: ${{ env.SLSA_PREDICATE_FILE }}
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check private repos
-        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/privacy-check@v2.1.0
         with:
           error_message: "Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log. Set 'private-repository' to override."
           override: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).builder.rekor_log_public }}
@@ -150,7 +150,7 @@ jobs:
           echo "$RUNNER: $RUNNER"
 
       - name: Checkout the tool repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: ${{ needs.verify-token.outputs.tool-repository }}
           ref: ${{ needs.verify-token.outputs.tool-ref }}
@@ -174,7 +174,7 @@ jobs:
           tree
 
       - name: Checkout the project repository
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0
         with:
           fetch-depth: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).source.checkout.fetch_depth }}
           checkout-sha1: ${{ fromJson(needs.verify-token.outputs.slsa-verified-token).source.checkout.sha1 }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload artifact layout file
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_ARTIFACTS_FILE }}"
           path: "${{ env.SLSA_ARTIFACTS_FILE }}"
@@ -232,14 +232,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the artifact layout file
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_ARTIFACTS_FILE }}"
           path: "${{ env.SLSA_ARTIFACTS_FILE }}"
           sha256: ${{ needs.build-artifacts-ubuntu.outputs.artifacts-layout-sha256 }}
 
       - name: Download the predicate file
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-${{ env.SLSA_PREDICATE_FILE }}"
           path: ${{ env.SLSA_PREDICATE_FILE }}
@@ -269,7 +269,7 @@ jobs:
 
       - name: Generate attestations
         id: attestations
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-attestations@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-attestations@v2.1.0
         with:
           slsa-layout-file: ${{ env.SLSA_ARTIFACTS_FILE }}
           predicate-type: ${{ steps.predicate-type.outputs.predicate-type }}
@@ -278,14 +278,14 @@ jobs:
 
       - name: Sign attestations
         id: sign
-        uses: slsa-framework/slsa-github-generator/.github/actions/sign-attestations@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/sign-attestations@v2.1.0
         with:
           attestations: attestations
           output-folder: "${{ needs.rng.outputs.value }}-slsa-attestations"
 
       - name: Upload attestations
         id: upload
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
         with:
           name: "${{ needs.rng.outputs.value }}-slsa-attestations"
           path: "${{ needs.rng.outputs.value }}-slsa-attestations"

--- a/.github/workflows/e2e.create-container_based-predicate.schedule.yml
+++ b/.github/workflows/e2e.create-container_based-predicate.schedule.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Detect the builder ref
         id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0
       - name: Update the build definition
         # We use a build definition hard-coded in testadata. To ensure validation against
         # workflow context, we must update the source references.

--- a/.github/workflows/generator_container_slsa3.yml
+++ b/.github/workflows/generator_container_slsa3.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Detect the generator ref
         id: detect
         continue-on-error: true
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0
 
       - name: Final outcome
         id: final
@@ -144,7 +144,7 @@ jobs:
       - name: Generate builder
         id: generate-builder
         continue-on-error: true
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/generator_generic_slsa3.yml
+++ b/.github/workflows/generator_generic_slsa3.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Detect the generator ref
         id: detect
         continue-on-error: true
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@v2.1.0
 
       - name: Final outcome
         id: final
@@ -156,7 +156,7 @@ jobs:
       - name: Generate builder
         id: generate-builder
         continue-on-error: true
-        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"
@@ -189,7 +189,7 @@ jobs:
         id: download-file
         continue-on-error: true
         if: inputs.base64-subjects-as-file != ''
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
         with:
           name: "${{ steps.metadata.outputs.artifact_name }}"
           path: "${{ steps.metadata.outputs.filename }}"
@@ -269,7 +269,7 @@ jobs:
       - name: Checkout builder repository
         id: checkout-builder
         continue-on-error: true
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
         with:
           repository: "${{ needs.detect-env.outputs.repository }}"
           ref: "${{ needs.detect-env.outputs.ref }}"

--- a/.github/workflows/pre-submit.e2e.maven.yml
+++ b/.github/workflows/pre-submit.e2e.maven.yml
@@ -30,6 +30,6 @@ jobs:
       id-token: write # For signing.
       contents: read # For repo checkout of private repos.
       actions: read # For getting workflow run on private repos.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.1.0
     with:
       directory: ./e2e/maven/workflow_dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       id-token: write # For signing.
       contents: write # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: "1.21"
       config-file: .github/workflows/configs-container/config-release.yml
@@ -75,7 +75,7 @@ jobs:
       id-token: write # For signing.
       contents: write # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: "1.21"
       config-file: .github/workflows/configs-generic/config-release.yml
@@ -88,7 +88,7 @@ jobs:
       id-token: write # For signing.
       contents: write # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: "1.21"
       config-file: .github/workflows/configs-go/config-release.yml
@@ -101,7 +101,7 @@ jobs:
       id-token: write # For signing.
       contents: write # For asset uploads.
       actions: read # For the entrypoint.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0-rc.3
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: "1.21"
       config-file: .github/workflows/configs-docker/config-release.yml

--- a/BYOB.md
+++ b/BYOB.md
@@ -80,7 +80,7 @@ The [slsa-github-generator](https://github.com/slsa-framework/slsa-github-genera
 The [setup-generic](https://github.com/slsa-framework/slsa-github-generator/blob/main/actions/delegator/setup-generic) Action is used to initialize the BYOB framework. It returns a so-called "SLSA token" which is used in later steps:
 
 ```yaml
-- uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.0.0
+- uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
 ```
 
 #### SLSA Reusable Workflow (SRW)
@@ -88,7 +88,7 @@ The [setup-generic](https://github.com/slsa-framework/slsa-github-generator/blob
 The SLSA Reuseable Workflow (SRW) acts as the build's orchestrator. It calls the TCA, generates provenance, and returns the provenance to its TRW caller. A TRW would typically call the SRW as follows:
 
 ```yaml
-- uses: slsa-framework/slsa-github-generator/.github/workflow/delegator_generic_slsa3.yml@v2.0.0
+- uses: slsa-framework/slsa-github-generator/.github/workflow/delegator_generic_slsa3.yml@v2.1.0
   with:
     slsa-token: ${{ needs.slsa-setup.outputs.slsa-token }}
 ```
@@ -159,7 +159,7 @@ One key difference between the Action and reusable workflow is isolation. The SR
 Our next step is to initialize the SRW framework. To do this, the TRW must invoke the [setup-generic Action](https://github.com/slsa-framework/slsa-github-generator/blob/main/actions/delegator/setup-generic/action.yml). The [relevant code](https://github.com/laurentsimon/byob-doc/blob/v0.0.1/.github/workflows/builder_example_slsa3.yml#L85-L94) calls the SSA as follows:
 
 ```yaml
-uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.0.0
+uses: slsa-framework/slsa-github-generator/actions/delegator/setup-generic@v2.1.0
   with:
     slsa-workflow-recipient: "delegator_generic_slsa3.yml"
     slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
@@ -190,7 +190,7 @@ slsa-run:
     contents: write # For asset uploads.
     packages: write # For package uploads.
     actions: read # For the entrypoint.
-  uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_generic_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/delegator_generic_slsa3.yml@v2.1.0
   with:
     slsa-token: ${{ needs.slsa-setup.outputs.slsa-token }}
   secrets:

--- a/actions/delegator/random/action.yml
+++ b/actions/delegator/random/action.yml
@@ -31,4 +31,4 @@ runs:
   steps:
     - name: Generate random value
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0

--- a/actions/delegator/secure-attestations-download/action.yml
+++ b/actions/delegator/secure-attestations-download/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the attestations
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/delegator/secure-download-folder/action.yml
+++ b/actions/delegator/secure-download-folder/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the folder
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/delegator/secure-upload-folder/action.yml
+++ b/actions/delegator/secure-upload-folder/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Upload the folder
       id: upload
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/generator/generic/create-base64-subjects-from-file/action.yml
+++ b/actions/generator/generic/create-base64-subjects-from-file/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Generate random value
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
     - name: Generate random name
       id: name
@@ -49,7 +49,7 @@ runs:
 
     - name: Upload file
       id: upload
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
       with:
         name: "${{ steps.name.outputs.artifact_name }}"
         path: "${{ inputs.path }}"

--- a/actions/gradle/publish/README.md
+++ b/actions/gradle/publish/README.md
@@ -237,7 +237,7 @@ jobs:
       contents: read
       actions: read
       packages: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_gradle_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_gradle_slsa3.yml@v2.1.0
     with:
       rekor-log-public: true
       artifact-list: build/libs/artifact1-0.1.18.jar,build/libs/artifact-0.1.18-javadoc.jar,build/libs/artifact-0.1.18-sources.jar
@@ -256,7 +256,7 @@ publish:
   steps:
     - name: publish
       id: publish
-      uses: slsa-framework/slsa-github-generator/actions/gradle/publish@v2.0.0
+      uses: slsa-framework/slsa-github-generator/actions/gradle/publish@v2.1.0
       with:
         provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
         provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"

--- a/actions/gradle/publish/action.yml
+++ b/actions/gradle/publish/action.yml
@@ -66,14 +66,14 @@ runs:
         gpg-private-key: ${{ inputs.gpg-private-key }}
         gpg-passphrase: GPG_KEY_PASS
     - name: Download the slsa attestation
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: "${{ inputs.provenance-download-name }}"
         path: ./
         sha256: "${{ inputs.provenance-download-sha256 }}"
 
     - name: Download the build dir
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: "${{ inputs.build-download-name }}"
         path: ./

--- a/actions/gradle/secure-download-attestations/action.yml
+++ b/actions/gradle/secure-download-attestations/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the attestation directory
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/gradle/secure-download-target/action.yml
+++ b/actions/gradle/secure-download-target/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the target directory
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/maven/publish/README.md
+++ b/actions/maven/publish/README.md
@@ -27,7 +27,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.1.0
     with:
       rekor-log-public: true
 ```
@@ -45,7 +45,7 @@ publish:
   steps:
     - name: publish
       id: publish
-      uses: slsa-framework/slsa-github-generator/actions/maven/publish@v2.0.0
+      uses: slsa-framework/slsa-github-generator/actions/maven/publish@v2.1.0
       with:
         provenance-download-name: "${{ needs.build.outputs.provenance-download-name }}"
         provenance-download-sha256: "${{ needs.build.outputs.provenance-download-sha256 }}"

--- a/actions/maven/publish/action.yml
+++ b/actions/maven/publish/action.yml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the project repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0-rc.3 # needed because we run javadoc and sources.
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-project-checkout@v2.1.0 # needed because we run javadoc and sources.
     - name: Set up Java for publishing to Maven Central Repository
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
       env:
@@ -62,24 +62,24 @@ runs:
         gpg-passphrase: GPG_KEY_PASS
 
     - name: Download the slsa attestation
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: "${{ inputs.provenance-download-name }}"
         path: slsa-attestations
         sha256: "${{ inputs.provenance-download-sha256 }}"
 
     - name: Download the target dir
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: "${{ inputs.target-download-name }}"
         path: ./
         sha256: "${{ inputs.target-download-sha256 }}"
 
     - name: Checkout the framework repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
       with:
         repository: slsa-framework/slsa-github-generator
-        ref: v2.1.0-rc.3
+        ref: v2.1.0
         path: __BUILDER_CHECKOUT_DIR__
 
     - name: Publish to the Maven Central Repository

--- a/actions/maven/secure-download-attestations/action.yml
+++ b/actions/maven/secure-download-attestations/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the attestation directory
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/maven/secure-download-target/action.yml
+++ b/actions/maven/secure-download-target/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the target directory
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/nodejs/publish/README.md
+++ b/actions/nodejs/publish/README.md
@@ -18,7 +18,7 @@ jobs:
       contents: read
       actions: read
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
     with:
       run-scripts: "ci, build"
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: publish
         id: publish
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@v2.1.0
         with:
           access: public
           node-auth-token: ${{ secrets.NPM_TOKEN }}

--- a/actions/nodejs/publish/action.yml
+++ b/actions/nodejs/publish/action.yml
@@ -56,14 +56,14 @@ runs:
         echo "path=${temp_dir}" >>"${GITHUB_OUTPUT}"
 
     - name: Download tarball
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
       with:
         name: ${{ inputs.package-download-name }}
         path: "${{ steps.temp-dir.outputs.path }}/${{ inputs.package-name }}"
         sha256: ${{ inputs.package-download-sha256 }}
 
     - name: Download provenance
-      uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.1.0
       with:
         name: ${{ inputs.provenance-download-name }}
         path: "${{ steps.temp-dir.outputs.path }}"

--- a/actions/nodejs/secure-attestations-download/README.md
+++ b/actions/nodejs/secure-attestations-download/README.md
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
     with:
       run-scripts: "ci, build"
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download provenance
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.1.0
         with:
           name: ${{ needs.build.outputs.provenance-download-name }}
           path: "attestations"

--- a/actions/nodejs/secure-attestations-download/action.yml
+++ b/actions/nodejs/secure-attestations-download/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the attestations
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-folder@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/actions/nodejs/secure-package-download/README.md
+++ b/actions/nodejs/secure-package-download/README.md
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
     with:
       run-scripts: "ci, build"
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download tarball
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-package-download@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-package-download@v2.1.0
         with:
           name: ${{ needs.build.outputs.package-download-name }}
           path: ${{ needs.build.outputs.package-name }}

--- a/actions/nodejs/secure-package-download/action.yml
+++ b/actions/nodejs/secure-package-download/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Download the package
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@v2.1.0
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/internal/builders/bazel/README.md
+++ b/internal/builders/bazel/README.md
@@ -87,7 +87,7 @@ jobs:
       contents: read # For repo checkout.
       actions: read # For getting workflow run info.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.1.0
     with:
       targets: "//src:fib //src:hello"
       flags: "--strip=always"
@@ -113,7 +113,7 @@ jobs:
       contents: read # For repo checkout.
       actions: read # For getting workflow run info.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.1.0
     with:
       targets: "//src:fib //src:hello"
       flags: "--strip=always"
@@ -137,7 +137,7 @@ jobs:
       contents: read # For repo checkout.
       actions: read # For getting workflow run info.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_bazel_slsa3.yml@v2.1.0
     with:
       targets: "//src:fib //src:hello"
       flags: "--strip=always"

--- a/internal/builders/bazel/action.yml
+++ b/internal/builders/bazel/action.yml
@@ -71,11 +71,11 @@ runs:
     # when multiple workflows run concurrently.
     - name: Generate random 16-byte value (32-char hex encoded)
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
     - name: Generate Artifacts
       id: generate-artifacts
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
       with:
         name: "${{ steps.rng.outputs.random }}-binaries"
         path: "./bazel_builder_binaries_to_upload_to_gh_7bc972367cb286b7f36ab4457f06e369" # path-to-artifact(s)

--- a/internal/builders/container/README.md
+++ b/internal/builders/container/README.md
@@ -73,7 +73,7 @@ provenance:
     id-token: write # for creating OIDC tokens for signing.
     packages: write # for uploading attestations.
   if: startsWith(github.ref, 'refs/tags/')
-  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
   with:
     image: ${{ needs.build.outputs.image }}
     digest: ${{ needs.build.outputs.digest }}
@@ -144,7 +144,7 @@ jobs:
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
@@ -373,7 +373,7 @@ This section explains how to generate non-forgeable SLSA provenance with existin
        # contents: read
        packages: write
      if: startsWith(github.ref, 'refs/tags/')
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
      with:
        image: ${{ needs.build.outputs.image }}
        digest: ${{ needs.build.outputs.digest }}
@@ -438,7 +438,7 @@ This section explains how to generate non-forgeable SLSA provenance with existin
          # contents: read
          packages: write
        if: startsWith(github.ref, 'refs/tags/')
-       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
        with:
          image: ${{ needs.build.outputs.image }}
          digest: ${{ needs.build.outputs.digest }}

--- a/internal/builders/docker/README.md
+++ b/internal/builders/docker/README.md
@@ -204,7 +204,7 @@ jobs:
       contents: write # To upload assets to release.
       actions: read # To read the workflow path.
     needs: args
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.1.0
     with:
       builder-image: "bash"
       builder-digest: "sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -96,7 +96,7 @@ provenance:
     actions: read # Needed for detection of GitHub Actions environment.
     id-token: write # Needed for provenance signing and ID
     contents: write # Needed for release uploads
-  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
   with:
     base64-subjects: "${{ needs.build.outputs.hashes }}"
 ```
@@ -114,7 +114,7 @@ build:
   outputs:
     subjects-as-file: ${{ steps.hashes.outputs.handle }}
   ...
-    uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.0.0
+    uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.1.0
     id: hashes
     with:
       path: large_digests_file.text
@@ -123,7 +123,7 @@ provenance:
     actions: read # Needed for detection of GitHub Actions environment.
     id-token: write # Needed for provenance signing and ID
     contents: write # Needed for release uploads
-  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
   with:
     base64-subjects-as-file: "${{ needs.build.outputs.subjects-as-file }}"
 ```
@@ -180,7 +180,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release
@@ -420,7 +420,7 @@ generate SLSA3 provenance by updating your existing workflow with the steps indi
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
        upload-assets: true # upload to a new release
@@ -462,7 +462,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
@@ -524,7 +524,7 @@ generate SLSA3 provenance by updating your existing workflow with the steps indi
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: ${{ needs.release.outputs.hashes }}
        upload-assets: true # upload to a new release
@@ -572,7 +572,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}
       upload-assets: true # upload to a new release
@@ -629,7 +629,7 @@ If you use [Bazel](https://bazel.build/) to generate your artifacts, you can eas
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -671,7 +671,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -729,7 +729,7 @@ steps indicated in the workflow below:
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -776,7 +776,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -825,7 +825,7 @@ jobs:
        actions: read
        id-token: write
        contents: write
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -868,7 +868,7 @@ Jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -919,7 +919,7 @@ steps indicated in the workflow below:
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -958,7 +958,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -1015,7 +1015,7 @@ workflow with the steps indicated in the workflow below.
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -1060,7 +1060,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -1125,7 +1125,7 @@ steps indicated in the workflow below:
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.build.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -1172,7 +1172,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -1263,7 +1263,7 @@ Regardless of your choice, there's unfortunately a bit of necessary boilerplate.
        actions: read # To read the workflow path.
        id-token: write # To sign the provenance.
        contents: write # To add assets to a release.
-     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
      with:
        base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
        upload-assets: true # Optional: Upload to a new release
@@ -1316,7 +1316,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
@@ -1356,7 +1356,7 @@ provenance:
     actions: read # To read the workflow path.
     id-token: write # To sign the provenance.
     contents: write # To add assets to a release.
-  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
   with:
     base64-subjects: "${{ needs.build.outputs[format('hash-{0}-{1}', matrix.color, matrix.flavor)] }}"
     upload-assets: true # Optional: Upload to a new release
@@ -1401,7 +1401,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs[format('hash-{0}-{1}', matrix.color, matrix.flavor)] }}"
       upload-assets: true # Optional: Upload to a new release
@@ -1504,7 +1504,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs[format('hash-{0}', matrix.os)] }}"
       upload-assets: true # NOTE: This does nothing unless 'upload-tag-name' parameter is also set to an existing tag
@@ -1569,7 +1569,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       upload-assets: true # NOTE: This does nothing unless 'upload-tag-name' parameter is also set to an existing tag
@@ -1633,7 +1633,7 @@ downloading the latest release. Make sure you continue to reference the workflow
 using a release tag in order to allow verification by `slsa-verifier`.
 
 ```yaml
-uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
 ```
 
 ### Compatibility with `actions/download-artifact`

--- a/internal/builders/go/README.md
+++ b/internal/builders/go/README.md
@@ -174,7 +174,7 @@ build:
       arch:
         - amd64
         - arm64
-  uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
+  uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
   with:
     go-version: 1.19
     config-file: .slsa-goreleaser/${{matrix.os}}-${{matrix.arch}}.yml
@@ -251,7 +251,7 @@ jobs:
       contents: write # To upload assets to release.
       actions: read # To read the workflow path.
     needs: args
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: 1.17
       # Optional: only needed if using ldflags.
@@ -420,7 +420,7 @@ the latest release. Make sure you continue to reference the workflow using a
 release tag in order to allow verification by `slsa-verifier`.
 
 ```yaml
-uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
+uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
 ```
 
 ### Compatibility with `actions/download-artifact`

--- a/internal/builders/gradle/README.md
+++ b/internal/builders/gradle/README.md
@@ -83,7 +83,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_gradle_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_gradle_slsa3.yml@v2.1.0
     with:
       artifact-list: >-
         ./build/artifact1.jar,

--- a/internal/builders/gradle/action.yml
+++ b/internal/builders/gradle/action.yml
@@ -101,7 +101,7 @@ runs:
     # when multiple workflows run concurrently.
     - name: Generate random 16-byte value (32-char hex encoded)
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
     - name: Put release artifacts in one directory
       shell: bash
@@ -128,7 +128,7 @@ runs:
         [[ "${PROJECT_ROOT}" -ef "${GITHUB_WORKSPACE}" ]] || mv "${PROJECT_ROOT}"/build "${GITHUB_WORKSPACE}"/
     - name: Upload build dir
       id: upload-build-dir
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
       with:
         name: "${{ steps.rng.outputs.random }}-build"
         path: build

--- a/internal/builders/maven/README.md
+++ b/internal/builders/maven/README.md
@@ -83,7 +83,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml@v2.1.0
 ```
 
 Now, when you invoke this workflow, the Maven builder will build both your artifacts and the provenance files for them.

--- a/internal/builders/maven/action.yml
+++ b/internal/builders/maven/action.yml
@@ -63,10 +63,10 @@ runs:
         distribution: temurin
         java-version: ${{ fromJson(inputs.slsa-workflow-inputs).jdk-version }}
     - name: Checkout the tool repository
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-builder-checkout@v2.1.0
       with:
         repository: slsa-framework/slsa-github-generator
-        ref: v2.1.0-rc.3
+        ref: v2.1.0
         path: __BUILDER_CHECKOUT_DIR__
     - name: Run mvn package
       shell: bash
@@ -113,11 +113,11 @@ runs:
     # when multiple workflows run concurrently.
     - name: Generate random 16-byte value (32-char hex encoded)
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
     - name: Upload target
       id: upload-target
-      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-folder@v2.1.0
       with:
         name: "${{ steps.rng.outputs.random }}-target"
         path: target

--- a/internal/builders/nodejs/README.md
+++ b/internal/builders/nodejs/README.md
@@ -121,7 +121,7 @@ jobs:
       contents: read # For repo checkout.
       actions: read # For getting workflow run info.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
     with:
       run-scripts: "ci, test, build"
 ```
@@ -154,7 +154,7 @@ publish:
 
     - name: publish
       id: publish
-      uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@v2.0.0
+      uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@v2.1.0
       with:
         access: public
         node-auth-token: ${{ secrets.NPM_TOKEN }}
@@ -197,14 +197,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Download tarball
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-package-download@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-package-download@v2.1.0
         with:
           name: ${{ needs.build.outputs.package-download-name }}
           path: ${{ needs.build.outputs.package-name }}
           sha256: ${{ needs.build.outputs.package-download-sha256 }}
 
       - name: Download provenance
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.0.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@v2.1.0
         with:
           name: ${{ needs.build.outputs.provenance-download-name }}
           path: "attestations"

--- a/internal/builders/nodejs/action.yml
+++ b/internal/builders/nodejs/action.yml
@@ -85,9 +85,9 @@ runs:
     # when multiple workflows run concurrently.
     - name: Generate random 16-byte value (32-char hex encoded)
       id: rng
-      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0-rc.3
+      uses: slsa-framework/slsa-github-generator/.github/actions/rng@v2.1.0
 
-    - uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0-rc.3
+    - uses: slsa-framework/slsa-github-generator/.github/actions/secure-upload-artifact@v2.1.0
       id: upload
       with:
         name: "${{ steps.rng.outputs.random }}-package.tgz"


### PR DESCRIPTION
#label:release v2.1.0

# Summary

Updates the workflows and docs to point to the new release v2.1.0

https://github.com/slsa-framework/slsa-github-generator/blob/main/RELEASE.md#verify-final-version-references

## Testing Process

~~Pre-submits should pass, except for the `references` workflow. The next step in the release process should fix this. https://github.com/slsa-framework/slsa-github-generator/blob/main/RELEASE.md#reference-actions-at-main~~
This should pass if you have `#label:release v2.1.0` in the PR description.

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [x] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
