### PR TITLE
fix: fix jq for the sigstore bundles

### DIFF
--- a/.github/actions/generate-builder/builder-fetch.sh
+++ b/.github/actions/generate-builder/builder-fetch.sh
@@ -101,7 +101,7 @@ chmod a+x "$VERIFIER_RELEASE_BINARY"
   "$BUILDER_RELEASE_BINARY" || exit 6
 
 builder_commit=$(gh api /repos/"$BUILDER_REPOSITORY"/git/ref/tags/"$builder_tag" | jq -r '.object.sha')
-provenance_commit=$(jq -r '.payload' <"$BUILDER_RELEASE_BINARY.intoto.jsonl" | base64 -d | jq -r '.predicate.materials[0].digest.sha1')
+provenance_commit=$(jq -r '.dsseEnvelope.payload' <"$BUILDER_RELEASE_BINARY.intoto.jsonl" | base64 -d | jq -r '.predicate.materials[0].digest.sha1')
 if [[ "$builder_commit" != "$provenance_commit" ]]; then
   echo "Builder commit sha $builder_commit != provenance material $provenance_commit"
   exit 5

--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -516,8 +516,8 @@ jobs:
         with:
           repository: ${{ steps.detect.outputs.repository }}
           ref: ${{ steps.detect.outputs.ref }}
-          builder-ref: "refs/tags/v1.6.0"
-          go-version: "1.21"
+          builder-ref: "refs/tags/v2.1.0"
+          go-version: "1.23.1"
           binary: "slsa-generator-generic-linux-amd64"
           directory: "internal/builders/generic"
           # NOTE: compile-builder explicitly set to false.

--- a/internal/builders/generic/README.md
+++ b/internal/builders/generic/README.md
@@ -288,7 +288,7 @@ The project generates SLSA provenance with the following values.
 | `buildType`                  | `"https://github.com/slsa-framework/slsa-github-generator/generic@v1"` | Identifies a generic GitHub Actions build.                                                                                                                                                                             |
 | `metadata.buildInvocationID` | `"[run_id]-[run_attempt]"`                                             | The GitHub Actions [`run_id`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) does not update when a workflow is re-run. Run attempt is added to make the build invocation ID unique. |
 
-**Note**: The generated provenance will probably be wrapped in a [DSSE](https://github.com/secure-systems-lab/dsse) envelope and encoded in base64. Check the human-readable result running `cat encoded-artifact.intoto.jsonl | jq -r '.payload' | base64 -d | jq`.
+**Note**: The generated provenance will probably be wrapped in a [DSSE](https://github.com/secure-systems-lab/dsse) envelope and encoded in base64. Check the human-readable result running `cat encoded-artifact.intoto.jsonl | jq -r '.dsseEnvelope.payload' | base64 -d | jq`.
 
 ### Provenance Example
 


### PR DESCRIPTION
#label:release v2.1.0

# Summary

fixes the jq of a script for the new sigstore bundles.

https://github.com/slsa-framework/example-package/actions/runs/13507076085/job/37739034806#step:2:226

```
jq: parse error: Invalid numeric literal at EOF at line 1, column 3
Error: Process completed with exit code 5.
```

## Testing Process

local testing of the same query against the [new provenance](https://github.com/slsa-framework/slsa-github-generator/releases/download/v2.1.0/slsa-builder-docker-linux-amd64.intoto.jsonl).

```
➜  jq -r '.dsseEnvelope.payload' <"$BUILDER_RELEASE_BINARY.intoto.jsonl" | base64 -d | jq -r '.predicate.materials[0].digest.sha1'
fbeecf0c1e9cbb70c6828b0d311037a9e6cce717
```

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [x] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [x] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
