### PR TITLE
fix: fix the Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/slsa-framework/slsa-github-generator
+module github.com/slsa-framework/slsa-github-generator/v2
 
 go 1.23.1
 

--- a/internal/builders/common/buildtype.go
+++ b/internal/builders/common/buildtype.go
@@ -14,7 +14,7 @@
 
 package common
 
-import "github.com/slsa-framework/slsa-github-generator/slsa"
+import "github.com/slsa-framework/slsa-github-generator/v2/slsa"
 
 // GenericBuild is a very generic build type where build type can be specified.
 type GenericBuild struct {

--- a/internal/builders/container/generate.go
+++ b/internal/builders/container/generate.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/internal/builders/common"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/builders/common"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 // generateCmd returns the 'generate' command.

--- a/internal/builders/container/generate_test.go
+++ b/internal/builders/container/generate_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 func checkTest(t *testing.T) func(err error) {

--- a/internal/builders/container/version.go
+++ b/internal/builders/container/version.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-github-generator/version"
+	"github.com/slsa-framework/slsa-github-generator/v2/version"
 )
 
 func versionCmd() *cobra.Command {

--- a/internal/builders/docker/commands.go
+++ b/internal/builders/docker/commands.go
@@ -29,8 +29,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/builders/docker/pkg"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/builders/docker/pkg"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 // DryRunCmd returns a new *cobra.Command that validates the input flags, and

--- a/internal/builders/docker/pkg/builder.go
+++ b/internal/builders/docker/pkg/builder.go
@@ -42,7 +42,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 var (

--- a/internal/builders/docker/pkg/config.go
+++ b/internal/builders/docker/pkg/config.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	toml "github.com/pelletier/go-toml"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 // BuildConfig is a collection of parameters to use for building the artifact.

--- a/internal/builders/generic/attest.go
+++ b/internal/builders/generic/attest.go
@@ -26,11 +26,11 @@ import (
 	"github.com/spf13/cobra"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/internal/builders/common"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/signing"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/builders/common"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 // attestCmd returns the 'attest' command.

--- a/internal/builders/generic/attest_test.go
+++ b/internal/builders/generic/attest_test.go
@@ -27,9 +27,9 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsacommon "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/testutil"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/testutil"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 const (

--- a/internal/builders/generic/main.go
+++ b/internal/builders/generic/main.go
@@ -20,7 +20,7 @@ import (
 	// TODO: Allow use of other OIDC providers?
 	// Enable the github OIDC auth provider.
 	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
-	"github.com/slsa-framework/slsa-github-generator/signing/sigstore"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing/sigstore"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/builders/generic/version.go
+++ b/internal/builders/generic/version.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-github-generator/version"
+	"github.com/slsa-framework/slsa-github-generator/v2/version"
 )
 
 func versionCmd() *cobra.Command {

--- a/internal/builders/go/main.go
+++ b/internal/builders/go/main.go
@@ -24,14 +24,14 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/signing/sigstore"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing/sigstore"
 
 	// Enable the GitHub OIDC auth provider.
 	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/builders/go/pkg"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/builders/go/pkg"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 func usage(p string) {

--- a/internal/builders/go/main_test.go
+++ b/internal/builders/go/main_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/builders/go/pkg"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/builders/go/pkg"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 func checkWorkingDir(t *testing.T, wd, expected string) {

--- a/internal/builders/go/pkg/build.go
+++ b/internal/builders/go/pkg/build.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/internal/runner"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/runner"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 var unknownTag = "unknown"

--- a/internal/builders/go/pkg/config.go
+++ b/internal/builders/go/pkg/config.go
@@ -23,7 +23,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
 )
 
 var supportedVersions = map[int]bool{

--- a/internal/builders/go/pkg/provenance.go
+++ b/internal/builders/go/pkg/provenance.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/slsa-framework/slsa-github-generator/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsacommon "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/internal/utils"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/utils"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 const (

--- a/internal/builders/go/pkg/provenance_test.go
+++ b/internal/builders/go/pkg/provenance_test.go
@@ -17,8 +17,8 @@ package pkg
 import (
 	"testing"
 
-	"github.com/slsa-framework/slsa-github-generator/internal/testutil"
-	"github.com/slsa-framework/slsa-github-generator/slsa"
+	"github.com/slsa-framework/slsa-github-generator/v2/internal/testutil"
+	"github.com/slsa-framework/slsa-github-generator/v2/slsa"
 )
 
 func TestGenerateProvenance(t *testing.T) {

--- a/internal/testutil/signing.go
+++ b/internal/testutil/signing.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/slsa-framework/slsa-github-generator/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
 )
 
 // TestAttestation is a basic Attestation implementation.

--- a/signing/sigstore/bundle.go
+++ b/signing/sigstore/bundle.go
@@ -23,8 +23,8 @@ import (
 	sigstoreBundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sigstoreRoot "github.com/sigstore/sigstore-go/pkg/root"
 	sigstoreSign "github.com/sigstore/sigstore-go/pkg/sign"
-	"github.com/slsa-framework/slsa-github-generator/github"
-	"github.com/slsa-framework/slsa-github-generator/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
 )
 
 // BundleSigner is used to produce Sigstore Bundles from provenance statements.

--- a/signing/sigstore/fulcio.go
+++ b/signing/sigstore/fulcio.go
@@ -25,8 +25,8 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/v2/pkg/providers"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
-	"github.com/slsa-framework/slsa-github-generator/signing"
-	"github.com/slsa-framework/slsa-github-generator/signing/envelope"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing/envelope"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 )

--- a/signing/sigstore/rekor.go
+++ b/signing/sigstore/rekor.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/slsa-framework/slsa-github-generator/signing"
+	"github.com/slsa-framework/slsa-github-generator/v2/signing"
 )
 
 const (

--- a/slsa/buildtype.go
+++ b/slsa/buildtype.go
@@ -26,7 +26,7 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
-	"github.com/slsa-framework/slsa-github-generator/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
 )
 
 // BuildType implements generation of buildType specific elements of SLSA

--- a/slsa/clientprovider.go
+++ b/slsa/clientprovider.go
@@ -19,7 +19,7 @@ import (
 
 	githubapi "github.com/google/go-github/v57/github"
 
-	"github.com/slsa-framework/slsa-github-generator/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
 )
 
 // ClientProvider creates Github API clients.

--- a/slsa/provenance_test.go
+++ b/slsa/provenance_test.go
@@ -23,7 +23,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsacommon "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
-	"github.com/slsa-framework/slsa-github-generator/github"
+	"github.com/slsa-framework/slsa-github-generator/v2/github"
 )
 
 var (


### PR DESCRIPTION
# Summary

This pull request replaces `"github.com/slsa-framework/slsa-github-generator` with `"github.com/slsa-framework/slsa-github-generator/v2`.

```sh
git_replace () {
	git grep -l "$1" | xargs -n 1 gsed -i "s|$1|$2|g"
}

git_replace '"github.com/slsa-framework/slsa-github-generator' '"github.com/slsa-framework/slsa-github-generator/v2'
```

The latest version of slsa-github-generator is https://github.com/slsa-framework/slsa-github-generator/releases/tag/v2.1.0 , so we should update the Go module path to `github.com/slsa-framework/slsa-github-generator/v2`.

Otherwise, packages are unavailable.

v1.10.0 is available.

```console
$ go install github.com/slsa-framework/slsa-github-generator/internal/builders/go@v1.10.0
```

But v2.1.0 is unavailable.

```console
$ go install github.com/slsa-framework/slsa-github-generator/internal/builders/go@v2.1.0 
go: github.com/slsa-framework/slsa-github-generator/internal/builders/go@v2.1.0: github.com/slsa-framework/slsa-github-generator@v2.1.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/slsa-framework/slsa-github-generator/v2")

$ go install github.com/slsa-framework/slsa-github-generator/v2/internal/builders/go@v2.1.0
go: github.com/slsa-framework/slsa-github-generator/v2/internal/builders/go@v2.1.0: github.com/slsa-framework/slsa-github-generator@v2.1.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/slsa-framework/slsa-github-generator/v2")
```

## Testing Process

...

## Checklist

- [x] Review the contributing [guidelines](https://github.com/slsa-framework/slsa-github-generator/blob/main/CONTRIBUTING.md)
- [ ] Add a reference to related issues in the PR description.
- [x] Update documentation if applicable.
- [x] Add unit tests if applicable.
- [ ] Add changes to the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/main/CHANGELOG.md) if applicable.
