### PR TITLE
fix: provide path to go.sum for caching

### DIFF
--- a/.github/actions/generate-builder/action.yml
+++ b/.github/actions/generate-builder/action.yml
@@ -79,6 +79,7 @@ runs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: ${{ inputs.go-version }}
+        cache-dependency-path: __BUILDER_CHECKOUT_DIR__/go.sum
 
     - name: Generate builder
       shell: bash


### PR DESCRIPTION
This prevents warnings about a missing dependency file.