### PR TITLE
docs: fix broken README anchor for slsa-verifier section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This issue is tracked by [issue #3350](https://github.com/slsa-framework/slsa-gi
 
 Use the [BYOB framework](BYOB.md) to create your own SLSA builder on GitHub. If you have an existing GitHub Action, you can use the BYOB framework to wrap it into a SLSA builder.
 This will harden the build process by running the Action in an isolated environment. Generated artifacts will meet Build Level 3 expectations and produce Build Level 3 provenance.
-To verify the provenance, your users can use the [slsa-verifier](#verification-of-provenance).
+To verify the provenance, your users can use the [slsa-verifier](#verify-provenance).
 
 ## Project Roadmap
 


### PR DESCRIPTION
## Summary
Fixes a broken internal anchor in README.

- before: [slsa-verifier](#verification-of-provenance)
- after: [slsa-verifier](#verify-provenance)

## Why
The previous link does not resolve to an existing heading, so readers cannot jump directly to the verification section.

## Scope
Docs-only update. No code, workflow, or release behavior changes.

## Context
This PR is opened as a parallel external-validation path while [ossf/scorecard#4942](https://github.com/ossf/scorecard/pull/4942) is awaiting maintainer workflow approval/review.

Signed-off-by: Ogulcan Aydogan <ogulcanaydogan@hotmail.com>